### PR TITLE
Fix ordering issue in subscription and change subscription to conform to AsyncSequence

### DIFF
--- a/Sources/BenchmarkPubSub/main.swift
+++ b/Sources/BenchmarkPubSub/main.swift
@@ -22,16 +22,13 @@ try await withThrowingTaskGroup(of: Void.self) { group in
         hm.append(try! HeaderName("foo"), HeaderValue("bar"))
         hm.append(try! HeaderName("foo"), HeaderValue("baz"))
         hm.insert(try! HeaderName("another"), HeaderValue("one"))
-        for i in 0..<numMsgs {
-            let msg = await sub.next()
-            guard let payload = msg?.payload else {
-                print("empty payload!")
-                continue
-            }
+        var i = 0
+        for await msg in sub {
+            let payload = msg.payload!
             if String(data: payload, encoding: .utf8) != "\(i)" {
                 print("invalid payload; expected: \(i); got: \(String(data: payload, encoding: .utf8))")
             }
-            guard let headers = msg?.headers else {
+            guard let headers = msg.headers else {
                 print("empty headers!")
                 continue
             }

--- a/Sources/NatsSwift/NatsSubscription.swift
+++ b/Sources/NatsSwift/NatsSubscription.swift
@@ -6,8 +6,9 @@
 import Foundation
 
 // TODO(pp): Implement slow consumer
-public class Subscription: AsyncIteratorProtocol {
+public class Subscription: AsyncSequence {
     public typealias Element = NatsMessage
+    public typealias AsyncIterator = SubscriptionIterator
 
     private var buffer: [Element]
     private let maxPending: UInt64
@@ -22,52 +23,66 @@ public class Subscription: AsyncIteratorProtocol {
         self.init(subject: subject, maxPending: Subscription.defaultMaxPending)
     }
 
-    init(subject: String, maxPending: uint64) {
+    init(subject: String, maxPending: UInt64) {
         self.subject = subject
         self.maxPending = maxPending
         self.buffer = []
     }
 
-    public func next() async -> Element? {
-        let msg: NatsMessage? = lock.withLock {
-            if closed {
-                return nil
-            }
-
-            if let message = buffer.first {
-                buffer.removeFirst()
-                return message
-            }
-            return nil
-        }
-        if let msg {
-            return msg
-        }
-        return await withCheckedContinuation { continuation in
-            lock.withLock{
-                self.continuation = continuation
-            }
-        }
+    public func makeAsyncIterator() -> SubscriptionIterator {
+        return SubscriptionIterator(subscription: self)
     }
 
     func receiveMessage(_ message: Element) {
         lock.withLock {
             if let continuation = self.continuation {
-                continuation.resume(returning: message)
+                // Immediately use the continuation if it exists
                 self.continuation = nil
+                continuation.resume(returning: message)
             } else if buffer.count < maxPending {
+                // Only append to buffer if no continuation is available
                 buffer.append(message)
             }
         }
-     }
+    }
 
-     func complete() async {
-         lock.withLock {
-             closed = true
-             continuation?.resume(returning: nil)
-         }
-     }
+    func complete() async {
+        lock.withLock {
+            closed = true
+            continuation?.resume(returning: nil)
+        }
+    }
 
+    // AsyncIterator implementation
+    public class SubscriptionIterator: AsyncIteratorProtocol {
+        private var subscription: Subscription
+
+        init(subscription: Subscription) {
+            self.subscription = subscription
+        }
+
+        public func next() async -> Element? {
+            await subscription.nextMessage()
+        }
+    }
+    
+    private func nextMessage() async -> Element? {
+        await withCheckedContinuation { continuation in
+            lock.withLock {
+                if closed {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                if let message = buffer.first {
+                    buffer.removeFirst()
+                    continuation.resume(returning: message)
+                } else {
+                    self.continuation = continuation
+                }
+            }
+        }
+    }
 }
 
 internal class SubscriptionCounter {

--- a/Tests/NatsSwiftTests/Integration/MessageWithHeadersTests.swift
+++ b/Tests/NatsSwiftTests/Integration/MessageWithHeadersTests.swift
@@ -32,7 +32,8 @@ class TestMessageWithHeadersTests: XCTestCase {
 
         try client.publish("hello".data(using: .utf8)!, subject: "foo", reply: nil, headers: hm)
 
-        let msg =  await sub.next()
+        let iter = sub.makeAsyncIterator()
+        let msg =  await iter.next()
         XCTAssertEqual(msg!.headers, hm)
 
     }


### PR DESCRIPTION
- Subscription now conforms to `AsyncSequence` protocol instead of `AsyncIterator`
- Fixed a race condition which caused messages in subscription to be out of order