### PR TITLE
Improve client builder and get rid of options form Client

### DIFF
--- a/Sources/NatsSwift/NatsClient/NatsClient.swift
+++ b/Sources/NatsSwift/NatsClient/NatsClient.swift
@@ -20,23 +20,12 @@ public enum NatsState {
 }
 
 public class Client {
-    var urls: [URL] = []
-    var pingInteval: TimeInterval = 1.0
-    var reconnectWait: TimeInterval = 2.0
-    var maxReconnects: Int? = nil
-
     internal let allocator = ByteBufferAllocator()
     internal var buffer: ByteBuffer
-    internal var connectionHandler: ConnectionHandler
+    internal var connectionHandler: ConnectionHandler?
 
     internal init() {
         self.buffer = allocator.buffer(capacity: 1024)
-        self.connectionHandler = ConnectionHandler(
-            inputBuffer: buffer,
-            urls: urls,
-            reconnectWait: reconnectWait,
-            maxReconnects: maxReconnects
-        )
     }
 }
 
@@ -45,21 +34,34 @@ extension Client {
         //TODO(jrm): reafactor for reconnection and review error handling.
         //TODO(jrm): handle response
         logger.debug("connect")
-        try await self.connectionHandler.connect()
+        guard let connectionHandler = self.connectionHandler else {
+            throw NSError(domain: "nats_swift", code: 1, userInfo: ["message": "empty connection handler"])
+        }
+        try await connectionHandler.connect()
     }
 
     public func publish(_ payload: Data, subject: String, reply: String? = nil, headers: HeaderMap? = nil) throws {
         logger.debug("publish")
-        try self.connectionHandler.write(operation: ClientOp.Publish((subject, reply, payload, headers)))
+        guard let connectionHandler = self.connectionHandler else {
+            throw NSError(domain: "nats_swift", code: 1, userInfo: ["message": "empty connection handler"])
+        }
+        try connectionHandler.write(operation: ClientOp.Publish((subject, reply, payload, headers)))
     }
 
     public func flush() async throws {
         logger.debug("flush")
-        self.connectionHandler.channel?.flush()
+        guard let connectionHandler = self.connectionHandler else {
+            throw NSError(domain: "nats_swift", code: 1, userInfo: ["message": "empty connection handler"])
+        }
+        connectionHandler.channel?.flush()
     }
 
     public func subscribe(to subject: String) async throws -> Subscription {
         logger.info("subscribe to subject \(subject)")
-        return try await self.connectionHandler.subscribe(subject)
+        guard let connectionHandler = self.connectionHandler else {
+            throw NSError(domain: "nats_swift", code: 1, userInfo: ["message": "empty connection handler"])
+        }
+        return try await connectionHandler.subscribe(subject)
+        
     }
 }

--- a/Sources/NatsSwift/NatsClient/NatsClientOptions.swift
+++ b/Sources/NatsSwift/NatsClient/NatsClientOptions.swift
@@ -10,7 +10,7 @@ import Dispatch
 
 public class ClientOptions {
     private var urls: [URL] = []
-    private var pingInterval: TimeInterval = 1.0
+    private var pingInterval: TimeInterval = 60.0
     private var reconnectWait: TimeInterval = 2.0
     private var maxReconnects: Int = 60
 
@@ -43,12 +43,14 @@ public class ClientOptions {
 
     public func build() -> Client {
         let client = Client()
-        client.urls = urls
-        client.pingInteval = pingInterval
-        client.reconnectWait = reconnectWait
-        client.maxReconnects = maxReconnects
+        client.connectionHandler = ConnectionHandler(
+            inputBuffer: client.buffer,
+            urls: urls,
+            reconnectWait: reconnectWait,
+            maxReconnects: maxReconnects,
+            pingInterval: pingInterval
+        )
         
-        client.connectionHandler.urls = urls
         return client
     }
 }

--- a/Sources/NatsSwift/NatsConnection.swift
+++ b/Sources/NatsSwift/NatsConnection.swift
@@ -18,6 +18,7 @@ class ConnectionHandler: ChannelInboundHandler {
     // nanoseconds representation of TimeInterval
     internal let reconnectWait: UInt64
     internal let maxReconnects: Int?
+    internal let pingInterval: TimeInterval
     
     typealias InboundIn = ByteBuffer
     internal var state: NatsState = .Pending
@@ -98,7 +99,7 @@ class ConnectionHandler: ChannelInboundHandler {
         }
         inputBuffer.clear()
     }
-    init(inputBuffer: ByteBuffer, urls: [URL], reconnectWait: TimeInterval, maxReconnects: Int?) {
+    init(inputBuffer: ByteBuffer, urls: [URL], reconnectWait: TimeInterval, maxReconnects: Int?, pingInterval: TimeInterval) {
         self.inputBuffer = self.allocator.buffer(capacity: 1024)
         self.urls = urls
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
@@ -106,6 +107,7 @@ class ConnectionHandler: ChannelInboundHandler {
         self.subscriptions = [UInt64:Subscription]()
         self.reconnectWait = UInt64(reconnectWait * 1_000_000_000)
         self.maxReconnects = maxReconnects
+        self.pingInterval = pingInterval
     }
     internal var group: MultiThreadedEventLoopGroup
     internal var channel: Channel?


### PR DESCRIPTION
This PR fixes `ClientBuilder` and gets rid of unnecessary option fields from `Client` itself. The initialization of `ConnectionHandler` now takes place only in `ClientBuilder`.