### PR TITLE
Improve loading resources and fix linter issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-SwiftyNats.xcodeproj
+Nats.xcodeproj
 
 ## Build generated
 build/

--- a/.swift-format
+++ b/.swift-format
@@ -16,7 +16,7 @@
     "prioritizeKeepingFunctionOutputTogether": true,
     "respectsExistingLineBreaks": true,
     "rules": {
-        "AllPublicDeclarationsHaveDocumentation": true,
+        "AllPublicDeclarationsHaveDocumentation": false,
         "AlwaysUseLiteralForEmptyCollectionInit": false,
         "AlwaysUseLowerCamelCase": true,
         "AmbiguousTrailingClosureOverload": true,

--- a/Sources/Nats/BatchBuffer.swift
+++ b/Sources/Nats/BatchBuffer.swift
@@ -102,10 +102,14 @@ class BatchBuffer {
                     self.isWriteInProgress = false
                     switch result {
                     case .success:
-                        self.waitingPromises.forEach { $0.succeed(()) }
+                        for promise in self.waitingPromises {
+                            promise.succeed(())
+                        }
                         self.waitingPromises.removeAll()
                     case .failure(let error):
-                        self.waitingPromises.forEach { $0.fail(error) }
+                        for promise in self.waitingPromises {
+                            promise.fail(error)
+                        }
                         self.waitingPromises.removeAll()
                     }
 

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -598,10 +598,9 @@ extension ConnectionHandler {
         let eventKind = event.kind()
         guard let handlerStore = self.eventHandlerStore[eventKind] else { return }
 
-        handlerStore.forEach {
-            $0.handler(event)
+        for handler in handlerStore {
+            handler.handler(event)
         }
-
     }
 
     internal func addListeners(

--- a/Sources/Nats/NatsProto.swift
+++ b/Sources/Nats/NatsProto.swift
@@ -113,7 +113,8 @@ internal struct HMessageInbound: Equatable {
             let headersLength = Int(String(decoding: lengthHeaders, as: UTF8.self)) ?? 0
             let length = Int(String(decoding: lengthData, as: UTF8.self)) ?? 0
             return HMessageInbound(
-                subject: subject, sid: sid, reply: replySubject, payload: nil, headers: NatsHeaderMap(),
+                subject: subject, sid: sid, reply: replySubject, payload: nil,
+                headers: NatsHeaderMap(),
                 headersLength: headersLength, length: length)
         }
 

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -368,7 +368,7 @@ class CoreNatsTests: XCTestCase {
         try await client.connect()
         let subscribe = try await client.subscribe(subject: "foo").makeAsyncIterator()
         try await client.publish("data".data(using: .utf8)!, subject: "foo")
-        let _ = await subscribe.next()
+        _ = await subscribe.next()
     }
 
     func testMutualTls() async throws {
@@ -513,7 +513,7 @@ class CoreNatsTests: XCTestCase {
         try await client.connect()
 
         do {
-            let _ = try await client.request("request".data(using: .utf8)!, subject: "service")
+            _ = try await client.request("request".data(using: .utf8)!, subject: "service")
         } catch NatsRequestError.noResponders {
             try await client.close()
             return
@@ -538,7 +538,7 @@ class CoreNatsTests: XCTestCase {
             }
         }
         do {
-            let _ = try await client.request(
+            _ = try await client.request(
                 "request".data(using: .utf8)!, subject: "service", timeout: 1)
         } catch NatsRequestError.timeout {
             try await service.unsubscribe()

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -294,14 +294,9 @@ class CoreNatsTests: XCTestCase {
 
     func testUsernameAndPassword() async throws {
         logger.logLevel = .debug
-        let currentFile = URL(fileURLWithPath: #file)
-        // Navigate up to the Tests directory
-        let testsDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
-        // Construct the path to the resource
-        let resourceURL =
-            testsDir
-            .appendingPathComponent("Integration/Resources/creds.conf", isDirectory: false)
-        natsServer.start(cfg: resourceURL.path)
+        let bundle = Bundle.module
+        natsServer.start(cfg: bundle.url(forResource: "creds", withExtension: "conf")!.relativePath)
+
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .usernameAndPassword("derek", "s3cr3t")
@@ -331,14 +326,9 @@ class CoreNatsTests: XCTestCase {
 
     func testTokenAuth() async throws {
         logger.logLevel = .debug
-        let currentFile = URL(fileURLWithPath: #file)
-        // Navigate up to the Tests directory
-        let testsDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
-        // Construct the path to the resource
-        let resourceURL =
-            testsDir
-            .appendingPathComponent("Integration/Resources/token.conf", isDirectory: false)
-        natsServer.start(cfg: resourceURL.path)
+        let bundle = Bundle.module
+        natsServer.start(cfg: bundle.url(forResource: "token", withExtension: "conf")!.relativePath)
+
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .token("s3cr3t")
@@ -367,50 +357,40 @@ class CoreNatsTests: XCTestCase {
 
     func testCredentialsAuth() async throws {
         logger.logLevel = .debug
-        let currentFile = URL(fileURLWithPath: #file)
-        // Navigate up to the Tests directory
-        let testsDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
-        // Construct the path to the resource
-        let resourceURL =
-            testsDir
-            .appendingPathComponent("Integration/Resources/jwt.conf", isDirectory: false)
-        natsServer.start(cfg: resourceURL.path)
-        print("server started with file: \(resourceURL.path)")
+        let bundle = Bundle.module
+        natsServer.start(cfg: bundle.url(forResource: "jwt", withExtension: "conf")!.relativePath)
 
-        let credsURL = testsDir.appendingPathComponent(
-            "Integration/Resources/TestUser.creds", isDirectory: false)
+        let creds = bundle.url(forResource: "TestUser", withExtension: "creds")!
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).credentialsFile(
-            credsURL
+            creds
         ).build()
         try await client.connect()
         let subscribe = try await client.subscribe(subject: "foo").makeAsyncIterator()
         try await client.publish("data".data(using: .utf8)!, subject: "foo")
-        let message = await subscribe.next()
-        print("message: \(message!.subject)")
+        let _ = await subscribe.next()
     }
 
     func testMutualTls() async throws {
+        let bundle = Bundle.module
         logger.logLevel = .debug
-        let currentFile = URL(fileURLWithPath: #file)
-        // Navigate up to the Tests directory
-        let testsDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
-        // Construct the path to the resource
-        let resourceURL =
-            testsDir
-            .appendingPathComponent("Integration/Resources/tls.conf", isDirectory: false)
-        natsServer.start(cfg: resourceURL.path)
-        let certsURL = testsDir.appendingPathComponent(
-            "Integration/Resources/certs/rootCA.pem", isDirectory: false)
+        let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
+        let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
+        let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
+        let cfgFile = try createConfigFileFromTemplate(templateURL: bundle.url(forResource: "tls", withExtension: "conf")!, args: [serverCert, serverKey, rootCA])
+        natsServer.start(cfg:cfgFile.relativePath)
+
+        let certsURL = bundle.url(forResource: "rootCA", withExtension: "pem")!
+        let clientCert = bundle.url(forResource: "client-cert", withExtension: "pem")!
+        let clientKey = bundle.url(forResource: "client-key", withExtension: "pem")!
+
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .requireTls()
             .rootCertificates(certsURL)
             .clientCertificate(
-                testsDir.appendingPathComponent(
-                    "Integration/Resources/certs/client-cert.pem", isDirectory: false),
-                testsDir.appendingPathComponent(
-                    "Integration/Resources/certs/client-key.pem", isDirectory: false)
+                clientCert,
+                clientKey
             )
             .build()
         try await client.connect()
@@ -421,26 +401,25 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testTlsFirst() async throws {
+        let bundle = Bundle.module
         logger.logLevel = .debug
-        let currentFile = URL(fileURLWithPath: #file)
-        // Navigate up to the Tests directory
-        let testsDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
-        // Construct the path to the resource
-        let resourceURL =
-            testsDir
-            .appendingPathComponent("Integration/Resources/tls_first.conf", isDirectory: false)
-        natsServer.start(cfg: resourceURL.path)
-        let certsURL = testsDir.appendingPathComponent(
-            "Integration/Resources/certs/rootCA.pem", isDirectory: false)
+        let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
+        let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
+        let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
+        let cfgFile = try createConfigFileFromTemplate(templateURL: bundle.url(forResource: "tls_first", withExtension: "conf")!, args: [serverCert, serverKey, rootCA])
+        natsServer.start(cfg:cfgFile.relativePath)
+
+        let certsURL = bundle.url(forResource: "rootCA", withExtension: "pem")!
+        let clientCert = bundle.url(forResource: "client-cert", withExtension: "pem")!
+        let clientKey = bundle.url(forResource: "client-key", withExtension: "pem")!
+
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .requireTls()
             .rootCertificates(certsURL)
             .clientCertificate(
-                testsDir.appendingPathComponent(
-                    "Integration/Resources/certs/client-cert.pem", isDirectory: false),
-                testsDir.appendingPathComponent(
-                    "Integration/Resources/certs/client-key.pem", isDirectory: false)
+                clientCert,
+                clientKey
             )
             .withTlsFirst()
             .build()
@@ -452,26 +431,25 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testInvalidCertificate() async throws {
+        let bundle = Bundle.module
         logger.logLevel = .debug
-        let currentFile = URL(fileURLWithPath: #file)
-        // Navigate up to the Tests directory
-        let testsDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
-        // Construct the path to the resource
-        let resourceURL =
-            testsDir
-            .appendingPathComponent("Integration/Resources/tls.conf", isDirectory: false)
-        natsServer.start(cfg: resourceURL.path)
-        let certsURL = testsDir.appendingPathComponent(
-            "Integration/Resources/certs/rootCA.pem", isDirectory: false)
+        let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
+        let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
+        let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
+        let cfgFile = try createConfigFileFromTemplate(templateURL: bundle.url(forResource: "tls", withExtension: "conf")!, args: [serverCert, serverKey, rootCA])
+        natsServer.start(cfg:cfgFile.relativePath)
+
+        let certsURL = bundle.url(forResource: "rootCA", withExtension: "pem")!
+        let invalidCert = bundle.url(forResource: "client-cert-invalid", withExtension: "pem")!
+        let invalidKey = bundle.url(forResource: "client-key-invalid", withExtension: "pem")!
+
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .requireTls()
             .rootCertificates(certsURL)
             .clientCertificate(
-                testsDir.appendingPathComponent(
-                    "Integration/Resources/certs/client-cert-invalid.pem", isDirectory: false),
-                testsDir.appendingPathComponent(
-                    "Integration/Resources/certs/client-key-invalid.pem", isDirectory: false)
+                invalidCert,
+                invalidKey
             )
             .build()
         do {
@@ -564,4 +542,19 @@ class CoreNatsTests: XCTestCase {
 
         XCTFail("Expected timeout")
     }
+
+    func createConfigFileFromTemplate(templateURL: URL, args: [String]) throws -> URL {
+        let templateContent = try String(contentsOf: templateURL, encoding: .utf8)
+        let config = String(format: templateContent, arguments: args.map { $0 as CVarArg })
+
+        let tempDirectoryURL = FileManager.default.temporaryDirectory
+        let tempFileURL = tempDirectoryURL.appendingPathComponent(UUID().uuidString).appendingPathExtension("conf")
+
+        // Write the filled content to the temp file
+        try config.write(to: tempFileURL, atomically: true, encoding: .utf8)
+
+        // Return the URL of the newly created temp file
+        return tempFileURL
+    }
+
 }

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -377,8 +377,10 @@ class CoreNatsTests: XCTestCase {
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
         let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
-        let cfgFile = try createConfigFileFromTemplate(templateURL: bundle.url(forResource: "tls", withExtension: "conf")!, args: [serverCert, serverKey, rootCA])
-        natsServer.start(cfg:cfgFile.relativePath)
+        let cfgFile = try createConfigFileFromTemplate(
+            templateURL: bundle.url(forResource: "tls", withExtension: "conf")!,
+            args: [serverCert, serverKey, rootCA])
+        natsServer.start(cfg: cfgFile.relativePath)
 
         let certsURL = bundle.url(forResource: "rootCA", withExtension: "pem")!
         let clientCert = bundle.url(forResource: "client-cert", withExtension: "pem")!
@@ -406,8 +408,10 @@ class CoreNatsTests: XCTestCase {
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
         let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
-        let cfgFile = try createConfigFileFromTemplate(templateURL: bundle.url(forResource: "tls_first", withExtension: "conf")!, args: [serverCert, serverKey, rootCA])
-        natsServer.start(cfg:cfgFile.relativePath)
+        let cfgFile = try createConfigFileFromTemplate(
+            templateURL: bundle.url(forResource: "tls_first", withExtension: "conf")!,
+            args: [serverCert, serverKey, rootCA])
+        natsServer.start(cfg: cfgFile.relativePath)
 
         let certsURL = bundle.url(forResource: "rootCA", withExtension: "pem")!
         let clientCert = bundle.url(forResource: "client-cert", withExtension: "pem")!
@@ -436,8 +440,10 @@ class CoreNatsTests: XCTestCase {
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
         let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
-        let cfgFile = try createConfigFileFromTemplate(templateURL: bundle.url(forResource: "tls", withExtension: "conf")!, args: [serverCert, serverKey, rootCA])
-        natsServer.start(cfg:cfgFile.relativePath)
+        let cfgFile = try createConfigFileFromTemplate(
+            templateURL: bundle.url(forResource: "tls", withExtension: "conf")!,
+            args: [serverCert, serverKey, rootCA])
+        natsServer.start(cfg: cfgFile.relativePath)
 
         let certsURL = bundle.url(forResource: "rootCA", withExtension: "pem")!
         let invalidCert = bundle.url(forResource: "client-cert-invalid", withExtension: "pem")!
@@ -548,7 +554,8 @@ class CoreNatsTests: XCTestCase {
         let config = String(format: templateContent, arguments: args.map { $0 as CVarArg })
 
         let tempDirectoryURL = FileManager.default.temporaryDirectory
-        let tempFileURL = tempDirectoryURL.appendingPathComponent(UUID().uuidString).appendingPathExtension("conf")
+        let tempFileURL = tempDirectoryURL.appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("conf")
 
         // Write the filled content to the temp file
         try config.write(to: tempFileURL, atomically: true, encoding: .utf8)

--- a/Tests/NatsTests/Integration/Resources/tls.conf
+++ b/Tests/NatsTests/Integration/Resources/tls.conf
@@ -2,9 +2,9 @@
 listen: localhost:4222
 
 tls {
-  cert_file:  "./Tests/NatsTests/Integration/Resources/certs/server-cert.pem"
-  key_file:   "./Tests/NatsTests/Integration/Resources/certs/server-key.pem"
-  ca_file:    "./Tests/NatsTests/Integration/Resources/certs/rootCA.pem"
+  cert_file:  "%@"
+  key_file:   "%@"
+  ca_file:    "%@"
   verify :    true
   timeout:    2
 }

--- a/Tests/NatsTests/Integration/Resources/tls_first.conf
+++ b/Tests/NatsTests/Integration/Resources/tls_first.conf
@@ -2,9 +2,9 @@
 listen: localhost:4222
 
 tls {
-  cert_file:  "./Tests/NatsTests/Integration/Resources/certs/server-cert.pem"
-  key_file:   "./Tests/NatsTests/Integration/Resources/certs/server-key.pem"
-  ca_file:    "./Tests/NatsTests/Integration/Resources/certs/rootCA.pem"
+  cert_file:  "%@"
+  key_file:   "%@"
+  ca_file:    "%@"
   verify :    true
   timeout:    2
   handshake_first: true

--- a/Tests/NatsTests/Unit/HeadersTests.swift
+++ b/Tests/NatsTests/Unit/HeadersTests.swift
@@ -48,10 +48,10 @@ class HeadersTests: XCTestCase {
         hm.append(try! NatsHeaderName("foo"), NatsHeaderValue("baz"))
         hm.insert(try! NatsHeaderName("bar"), NatsHeaderValue("foo"))
 
-        let expected = "NATS/1.0\r\nfoo:bar\r\nfoo:baz\r\nbar:foo\r\n\r\n"
-        let byteArray: [UInt8] = Array(expected.utf8)
+        let expected = ["NATS/1.0\r\nfoo:bar\r\nfoo:baz\r\nbar:foo\r\n\r\n",
+                        "NATS/1.0\r\nbar:foo\r\nfoo:bar\r\nfoo:baz\r\n\r\n"]
 
-        XCTAssertEqual(hm.toBytes(), byteArray)
+        XCTAssertTrue(expected.contains(String(bytes: hm.toBytes(), encoding: .utf8)!))
     }
 
     func testValidNatsHeaderName() {

--- a/Tests/NatsTests/Unit/HeadersTests.swift
+++ b/Tests/NatsTests/Unit/HeadersTests.swift
@@ -25,7 +25,10 @@ class HeadersTests: XCTestCase {
         ("testValidNatsHeaderName", testValidNatsHeaderName),
         ("testDollarNatsHeaderName", testDollarNatsHeaderName),
         ("testInvalidNatsHeaderName", testInvalidNatsHeaderName),
-        ("testInvalidNatsHeaderNameWithSpecialCharacters", testInvalidNatsHeaderNameWithSpecialCharacters),
+        (
+            "testInvalidNatsHeaderNameWithSpecialCharacters",
+            testInvalidNatsHeaderNameWithSpecialCharacters
+        ),
 
     ]
 
@@ -33,7 +36,8 @@ class HeadersTests: XCTestCase {
         var hm = NatsHeaderMap()
         hm.append(try! NatsHeaderName("foo"), NatsHeaderValue("bar"))
         hm.append(try! NatsHeaderName("foo"), NatsHeaderValue("baz"))
-        XCTAssertEqual(hm.getAll(try! NatsHeaderName("foo")), [NatsHeaderValue("bar"), NatsHeaderValue("baz")])
+        XCTAssertEqual(
+            hm.getAll(try! NatsHeaderName("foo")), [NatsHeaderValue("bar"), NatsHeaderValue("baz")])
     }
 
     func testInsert() {
@@ -48,8 +52,10 @@ class HeadersTests: XCTestCase {
         hm.append(try! NatsHeaderName("foo"), NatsHeaderValue("baz"))
         hm.insert(try! NatsHeaderName("bar"), NatsHeaderValue("foo"))
 
-        let expected = ["NATS/1.0\r\nfoo:bar\r\nfoo:baz\r\nbar:foo\r\n\r\n",
-                        "NATS/1.0\r\nbar:foo\r\nfoo:bar\r\nfoo:baz\r\n\r\n"]
+        let expected = [
+            "NATS/1.0\r\nfoo:bar\r\nfoo:baz\r\nbar:foo\r\n\r\n",
+            "NATS/1.0\r\nbar:foo\r\nfoo:bar\r\nfoo:baz\r\n\r\n",
+        ]
 
         XCTAssertTrue(expected.contains(String(bytes: hm.toBytes(), encoding: .utf8)!))
     }


### PR DESCRIPTION
- Use `Bundle` for reading test resources - this allows for executing tests using both `swift test` as well as in Xcode or with `xcodebuild`
- Fix linter issues and format code

These fixes will make linter check in https://github.com/nats-io/nats.swift/pull/58 pass.