### PR TITLE
Fixed websocket path

### DIFF
--- a/Sources/Nats/HTTPUpgradeRequestHandler.swift
+++ b/Sources/Nats/HTTPUpgradeRequestHandler.swift
@@ -28,7 +28,10 @@ internal final class HTTPUpgradeRequestHandler: ChannelInboundHandler, Removable
 
     private var requestSent = false
 
-    init(host: String, path: String, query: String?, headers: HTTPHeaders, upgradePromise: EventLoopPromise<Void>) {
+    init(
+        host: String, path: String, query: String?, headers: HTTPHeaders,
+        upgradePromise: EventLoopPromise<Void>
+    ) {
         self.host = host
         self.path = path
         self.query = query
@@ -58,7 +61,8 @@ internal final class HTTPUpgradeRequestHandler: ChannelInboundHandler, Removable
         headers.add(name: "Host", value: self.host)
 
         var uri: String
-        if self.path.hasPrefix("/") || self.path.hasPrefix("ws://") || self.path.hasPrefix("wss://") {
+        if self.path.hasPrefix("/") || self.path.hasPrefix("ws://") || self.path.hasPrefix("wss://")
+        {
             uri = self.path
         } else {
             uri = "/" + self.path

--- a/Sources/Nats/HTTPUpgradeRequestHandler.swift
+++ b/Sources/Nats/HTTPUpgradeRequestHandler.swift
@@ -21,13 +21,18 @@ internal final class HTTPUpgradeRequestHandler: ChannelInboundHandler, Removable
     typealias OutboundOut = HTTPClientRequestPart
 
     let host: String
-    let headers = HTTPHeaders()
+    let path: String
+    let query: String?
+    let headers: HTTPHeaders
     let upgradePromise: EventLoopPromise<Void>
 
     private var requestSent = false
 
-    init(host: String, upgradePromise: EventLoopPromise<Void>) {
+    init(host: String, path: String, query: String?, headers: HTTPHeaders, upgradePromise: EventLoopPromise<Void>) {
         self.host = host
+        self.path = path
+        self.query = query
+        self.headers = headers
         self.upgradePromise = upgradePromise
     }
 
@@ -52,10 +57,21 @@ internal final class HTTPUpgradeRequestHandler: ChannelInboundHandler, Removable
         var headers = self.headers
         headers.add(name: "Host", value: self.host)
 
+        var uri: String
+        if self.path.hasPrefix("/") || self.path.hasPrefix("ws://") || self.path.hasPrefix("wss://") {
+            uri = self.path
+        } else {
+            uri = "/" + self.path
+        }
+
+        if let query = self.query {
+            uri += "?\(query)"
+        }
+
         let requestHead = HTTPRequestHead(
             version: HTTPVersion(major: 1, minor: 1),
             method: .GET,
-            uri: "/",
+            uri: uri,
             headers: headers
         )
         context.write(self.wrapOutboundOut(.head(requestHead)), promise: nil)

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -438,7 +438,7 @@ class ConnectionHandler: ChannelInboundHandler {
                             host: server.host ?? "localhost",
                             path: server.path,
                             query: server.query,
-                            headers: HTTPHeaders(), // TODO (mtmk): pass in from client options
+                            headers: HTTPHeaders(),  // TODO (mtmk): pass in from client options
                             upgradePromise: upgradePromise)
                         let httpUpgradeRequestHandlerBox = NIOLoopBound(
                             httpUpgradeRequestHandler, eventLoop: channel.eventLoop)

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -434,10 +434,12 @@ class ConnectionHandler: ChannelInboundHandler {
                     }
                 } else {
                     if server.scheme == "ws" || server.scheme == "wss" {
-                        let host = server.host ?? "localhost"
-                        let port = server.port ?? 80
                         let httpUpgradeRequestHandler = HTTPUpgradeRequestHandler(
-                            host: "\(host):\(port)", upgradePromise: upgradePromise)
+                            host: server.host ?? "localhost",
+                            path: server.path,
+                            query: server.query,
+                            headers: HTTPHeaders(), // TODO (mtmk): pass in from client options
+                            upgradePromise: upgradePromise)
                         let httpUpgradeRequestHandlerBox = NIOLoopBound(
                             httpUpgradeRequestHandler, eventLoop: channel.eventLoop)
 


### PR DESCRIPTION
Allow path to be passed into websocket connection so that if there is a proxy in between it can be setup with a path on the proxy server even though it doesn't matter for the server connection.

Also there is a future option we can introduce to pass HTTP headers in case application might use them to authenticate with the proxy for example.

Note: this feature was already present in the original websocket-kit code and I chose to simplify it at the time.