### PR TITLE
Fix another promise leak

### DIFF
--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -272,14 +272,14 @@ class ConnectionHandler: ChannelInboundHandler {
                 do {
                     let (bootstrap, upgradePromise) = try self.bootstrapConnection(to: s)
                     guard let host = s.host, let port = s.port else {
-                        upgradePromise.succeed() // avoid promise leaks
+                        upgradePromise.succeed()  // avoid promise leaks
                         throw NatsConfigError("no url")
                     }
                     let connect = bootstrap.connect(host: host, port: port)
                     connect.cascadeFailure(to: upgradePromise)
                     self.channel = try await connect.get()
                     guard let channel = self.channel else {
-                        upgradePromise.succeed() // avoid promise leaks
+                        upgradePromise.succeed()  // avoid promise leaks
                         throw NatsClientError("internal error: empty channel")
                     }
 

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -272,10 +272,14 @@ class ConnectionHandler: ChannelInboundHandler {
                 do {
                     let (bootstrap, upgradePromise) = try self.bootstrapConnection(to: s)
                     guard let host = s.host, let port = s.port else {
+                        upgradePromise.succeed() // avoid promise leaks
                         throw NatsConfigError("no url")
                     }
-                    self.channel = try await bootstrap.connect(host: host, port: port).get()
+                    let connect = bootstrap.connect(host: host, port: port)
+                    connect.cascadeFailure(to: upgradePromise)
+                    self.channel = try await connect.get()
                     guard let channel = self.channel else {
+                        upgradePromise.succeed() // avoid promise leaks
                         throw NatsClientError("internal error: empty channel")
                     }
 


### PR DESCRIPTION
This was being triggered when port was not passed part of the url e.g. wss://example.com/some/path as opposed to wss://example.com:443/some/path

Also added couple more locations fulfilling the promise in case of other errors.