### PR TITLE
Fixed missing public access modifiers

### DIFF
--- a/Sources/JetStream/JetStreamContext.swift
+++ b/Sources/JetStream/JetStreamContext.swift
@@ -53,7 +53,7 @@ extension JetStreamContext {
         return AckFuture(sub: sub, timeout: self.timeout)
     }
 
-    internal func request<T: Codable>(
+    public func request<T: Codable>(
         _ subject: String, message: Data? = nil
     ) async throws -> Response<T> {
         let data = message ?? Data()
@@ -72,7 +72,7 @@ extension JetStreamContext {
 public struct AckFuture {
     let sub: NatsSubscription
     let timeout: TimeInterval
-    func wait() async throws -> Ack {
+    public func wait() async throws -> Ack {
         let response = try await withThrowingTaskGroup(
             of: NatsMessage?.self,
             body: { group in

--- a/Sources/JetStream/JetStreamError.swift
+++ b/Sources/JetStream/JetStreamError.swift
@@ -14,15 +14,15 @@
 import Foundation
 
 public struct JetStreamAPIResponse: Codable {
-    let type: String
-    let error: JetStreamError
+    public let type: String
+    public let error: JetStreamError
 }
 
 public struct JetStreamError: Codable, Error {
-    var code: UInt
+    public var code: UInt
     //FIXME(jrm): This should be mapped to predefined JetStream errors from the server.
-    var errorCode: ErrorCode
-    var description: String?
+    public var errorCode: ErrorCode
+    public var description: String?
 
     enum CodingKeys: String, CodingKey {
         case code = "code"
@@ -31,472 +31,472 @@ public struct JetStreamError: Codable, Error {
     }
 }
 
-struct ErrorCode: Codable, Equatable {
-    let rawValue: UInt64
+public struct ErrorCode: Codable, Equatable {
+    public let rawValue: UInt64
     /// Peer not a member
-    static let clusterPeerNotMember = ErrorCode(rawValue: 10040)
+    public static let clusterPeerNotMember = ErrorCode(rawValue: 10040)
 
     /// Consumer expected to be ephemeral but detected a durable name set in subject
-    static let consumerEphemeralWithDurable = ErrorCode(rawValue: 10019)
+    public static let consumerEphemeralWithDurable = ErrorCode(rawValue: 10019)
 
     /// Stream external delivery prefix overlaps with stream subject
-    static let streamExternalDeletePrefixOverlaps = ErrorCode(rawValue: 10022)
+    public static let streamExternalDeletePrefixOverlaps = ErrorCode(rawValue: 10022)
 
     /// Resource limits exceeded for account
-    static let accountResourcesExceeded = ErrorCode(rawValue: 10002)
+    public static let accountResourcesExceeded = ErrorCode(rawValue: 10002)
 
     /// Jetstream system temporarily unavailable
-    static let clusterNotAvailable = ErrorCode(rawValue: 10008)
+    public static let clusterNotAvailable = ErrorCode(rawValue: 10008)
 
     /// Subjects overlap with an existing stream
-    static let streamSubjectOverlap = ErrorCode(rawValue: 10065)
+    public static let streamSubjectOverlap = ErrorCode(rawValue: 10065)
 
     /// Wrong last sequence
-    static let streamWrongLastSequence = ErrorCode(rawValue: 10071)
+    public static let streamWrongLastSequence = ErrorCode(rawValue: 10071)
 
     /// Template name in subject does not match request
-    static let nameNotMatchSubject = ErrorCode(rawValue: 10073)
+    public static let nameNotMatchSubject = ErrorCode(rawValue: 10073)
 
     /// No suitable peers for placement
-    static let clusterNoPeers = ErrorCode(rawValue: 10005)
+    public static let clusterNoPeers = ErrorCode(rawValue: 10005)
 
     /// Consumer expected to be ephemeral but a durable name was set in request
-    static let consumerEphemeralWithDurableName = ErrorCode(rawValue: 10020)
+    public static let consumerEphemeralWithDurableName = ErrorCode(rawValue: 10020)
 
     /// Insufficient resources
-    static let insufficientResources = ErrorCode(rawValue: 10023)
+    public static let insufficientResources = ErrorCode(rawValue: 10023)
 
     /// Stream mirror must have max message size >= source
-    static let mirrorMaxMessageSizeTooBig = ErrorCode(rawValue: 10030)
+    public static let mirrorMaxMessageSizeTooBig = ErrorCode(rawValue: 10030)
 
     /// Generic error from stream deletion operation
-    static let streamDeleteFailed = ErrorCode(rawValue: 10067)
+    public static let streamDeleteFailed = ErrorCode(rawValue: 10067)
 
     /// Bad request
-    static let badRequest = ErrorCode(rawValue: 10003)
+    public static let badRequest = ErrorCode(rawValue: 10003)
 
     /// Not currently supported in clustered mode
-    static let notSupportedInClusterMode = ErrorCode(rawValue: 10036)
+    public static let notSupportedInClusterMode = ErrorCode(rawValue: 10036)
 
     /// Consumer not found
-    static let consumerNotFound = ErrorCode(rawValue: 10014)
+    public static let consumerNotFound = ErrorCode(rawValue: 10014)
 
     /// Stream source must have max message size >= target
-    static let sourceMaxMessageSizeTooBig = ErrorCode(rawValue: 10046)
+    public static let sourceMaxMessageSizeTooBig = ErrorCode(rawValue: 10046)
 
     /// Generic error when stream operation fails.
-    static let streamAssignment = ErrorCode(rawValue: 10048)
+    public static let streamAssignment = ErrorCode(rawValue: 10048)
 
     /// Message size exceeds maximum allowed
-    static let streamMessageExceedsMaximum = ErrorCode(rawValue: 10054)
+    public static let streamMessageExceedsMaximum = ErrorCode(rawValue: 10054)
 
     /// Generic error for stream creation error with a string
-    static let streamCreateTemplate = ErrorCode(rawValue: 10066)
+    public static let streamCreateTemplate = ErrorCode(rawValue: 10066)
 
     /// Invalid JSON
-    static let invalidJson = ErrorCode(rawValue: 10025)
+    public static let invalidJson = ErrorCode(rawValue: 10025)
 
     /// Stream external delivery prefix must not contain wildcards
-    static let streamInvalidExternalDeliverySubject = ErrorCode(rawValue: 10024)
+    public static let streamInvalidExternalDeliverySubject = ErrorCode(rawValue: 10024)
 
     /// Restore failed
-    static let streamRestore = ErrorCode(rawValue: 10062)
+    public static let streamRestore = ErrorCode(rawValue: 10062)
 
     /// Incomplete results
-    static let clusterIncomplete = ErrorCode(rawValue: 10004)
+    public static let clusterIncomplete = ErrorCode(rawValue: 10004)
 
     /// Account not found
-    static let noAccount = ErrorCode(rawValue: 10035)
+    public static let noAccount = ErrorCode(rawValue: 10035)
 
     /// General RAFT error
-    static let raftGeneral = ErrorCode(rawValue: 10041)
+    public static let raftGeneral = ErrorCode(rawValue: 10041)
 
     /// Jetstream unable to subscribe to restore snapshot
-    static let restoreSubscribeFailed = ErrorCode(rawValue: 10042)
+    public static let restoreSubscribeFailed = ErrorCode(rawValue: 10042)
 
     /// Stream deletion failed
-    static let streamDelete = ErrorCode(rawValue: 10050)
+    public static let streamDelete = ErrorCode(rawValue: 10050)
 
     /// Stream external api prefix must not overlap
-    static let streamExternalApiOverlap = ErrorCode(rawValue: 10021)
+    public static let streamExternalApiOverlap = ErrorCode(rawValue: 10021)
 
     /// Stream mirrors can not contain subjects
-    static let mirrorWithSubjects = ErrorCode(rawValue: 10034)
+    public static let mirrorWithSubjects = ErrorCode(rawValue: 10034)
 
     /// Jetstream not enabled
-    static let jetstreamNotEnabled = ErrorCode(rawValue: 10076)
+    public static let jetstreamNotEnabled = ErrorCode(rawValue: 10076)
 
     /// Jetstream not enabled for account
-    static let jetstreamNotEnabledForAccount = ErrorCode(rawValue: 10039)
+    public static let jetstreamNotEnabledForAccount = ErrorCode(rawValue: 10039)
 
     /// Sequence not found
-    static let sequenceNotFound = ErrorCode(rawValue: 10043)
+    public static let sequenceNotFound = ErrorCode(rawValue: 10043)
 
     /// Stream mirror configuration can not be updated
-    static let streamMirrorNotUpdatable = ErrorCode(rawValue: 10055)
+    public static let streamMirrorNotUpdatable = ErrorCode(rawValue: 10055)
 
     /// Expected stream sequence does not match
-    static let streamSequenceNotMatch = ErrorCode(rawValue: 10063)
+    public static let streamSequenceNotMatch = ErrorCode(rawValue: 10063)
 
     /// Wrong last msg id
-    static let streamWrongLastMessageId = ErrorCode(rawValue: 10070)
+    public static let streamWrongLastMessageId = ErrorCode(rawValue: 10070)
 
     /// Jetstream unable to open temp storage for restore
-    static let tempStorageFailed = ErrorCode(rawValue: 10072)
+    public static let tempStorageFailed = ErrorCode(rawValue: 10072)
 
     /// Insufficient storage resources available
-    static let storageResourcesExceeded = ErrorCode(rawValue: 10047)
+    public static let storageResourcesExceeded = ErrorCode(rawValue: 10047)
 
     /// Stream name in subject does not match request
-    static let streamMismatch = ErrorCode(rawValue: 10056)
+    public static let streamMismatch = ErrorCode(rawValue: 10056)
 
     /// Expected stream does not match
-    static let streamNotMatch = ErrorCode(rawValue: 10060)
+    public static let streamNotMatch = ErrorCode(rawValue: 10060)
 
     /// Setting up consumer mirror failed
-    static let mirrorConsumerSetupFailed = ErrorCode(rawValue: 10029)
+    public static let mirrorConsumerSetupFailed = ErrorCode(rawValue: 10029)
 
     /// Expected an empty request payload
-    static let notEmptyRequest = ErrorCode(rawValue: 10038)
+    public static let notEmptyRequest = ErrorCode(rawValue: 10038)
 
     /// Stream name already in use with a different configuration
-    static let streamNameExist = ErrorCode(rawValue: 10058)
+    public static let streamNameExist = ErrorCode(rawValue: 10058)
 
     /// Tags placement not supported for operation
-    static let clusterTags = ErrorCode(rawValue: 10011)
+    public static let clusterTags = ErrorCode(rawValue: 10011)
 
     /// Maximum consumers limit reached
-    static let maximumConsumersLimit = ErrorCode(rawValue: 10026)
+    public static let maximumConsumersLimit = ErrorCode(rawValue: 10026)
 
     /// General source consumer setup failure
-    static let sourceConsumerSetupFailed = ErrorCode(rawValue: 10045)
+    public static let sourceConsumerSetupFailed = ErrorCode(rawValue: 10045)
 
     /// Consumer creation failed
-    static let consumerCreate = ErrorCode(rawValue: 10012)
+    public static let consumerCreate = ErrorCode(rawValue: 10012)
 
     /// Consumer expected to be durable but no durable name set in subject
-    static let consumerDurableNameNotInSubject = ErrorCode(rawValue: 10016)
+    public static let consumerDurableNameNotInSubject = ErrorCode(rawValue: 10016)
 
     /// Stream limits error
-    static let streamLimits = ErrorCode(rawValue: 10053)
+    public static let streamLimits = ErrorCode(rawValue: 10053)
 
     /// Replicas configuration can not be updated
-    static let streamReplicasNotUpdatable = ErrorCode(rawValue: 10061)
+    public static let streamReplicasNotUpdatable = ErrorCode(rawValue: 10061)
 
     /// Template not found
-    static let streamTemplateNotFound = ErrorCode(rawValue: 10068)
+    public static let streamTemplateNotFound = ErrorCode(rawValue: 10068)
 
     /// Jetstream cluster not assigned to this server
-    static let clusterNotAssigned = ErrorCode(rawValue: 10007)
+    public static let clusterNotAssigned = ErrorCode(rawValue: 10007)
 
     /// Jetstream cluster can't handle request
-    static let clusterNotLeader = ErrorCode(rawValue: 10009)
+    public static let clusterNotLeader = ErrorCode(rawValue: 10009)
 
     /// Consumer name already in use
-    static let consumerNameExist = ErrorCode(rawValue: 10013)
+    public static let consumerNameExist = ErrorCode(rawValue: 10013)
 
     /// Stream mirrors can't also contain other sources
-    static let mirrorWithSources = ErrorCode(rawValue: 10031)
+    public static let mirrorWithSources = ErrorCode(rawValue: 10031)
 
     /// Stream not found
-    static let streamNotFound = ErrorCode(rawValue: 10059)
+    public static let streamNotFound = ErrorCode(rawValue: 10059)
 
     /// Jetstream clustering support required
-    static let clusterRequired = ErrorCode(rawValue: 10010)
+    public static let clusterRequired = ErrorCode(rawValue: 10010)
 
     /// Consumer expected to be durable but a durable name was not set
-    static let consumerDurableNameNotSet = ErrorCode(rawValue: 10018)
+    public static let consumerDurableNameNotSet = ErrorCode(rawValue: 10018)
 
     /// Maximum number of streams reached
-    static let maximumStreamsLimit = ErrorCode(rawValue: 10027)
+    public static let maximumStreamsLimit = ErrorCode(rawValue: 10027)
 
     /// Stream mirrors can not have both start seq and start time configured
-    static let mirrorWithStartSequenceAndTime = ErrorCode(rawValue: 10032)
+    public static let mirrorWithStartSequenceAndTime = ErrorCode(rawValue: 10032)
 
     /// Stream snapshot failed
-    static let streamSnapshot = ErrorCode(rawValue: 10064)
+    public static let streamSnapshot = ErrorCode(rawValue: 10064)
 
     /// Stream update failed
-    static let streamUpdate = ErrorCode(rawValue: 10069)
+    public static let streamUpdate = ErrorCode(rawValue: 10069)
 
     /// Jetstream not in clustered mode
-    static let clusterNotActive = ErrorCode(rawValue: 10006)
+    public static let clusterNotActive = ErrorCode(rawValue: 10006)
 
     /// Consumer name in subject does not match durable name in request
-    static let consumerDurableNameNotMatchSubject = ErrorCode(rawValue: 10017)
+    public static let consumerDurableNameNotMatchSubject = ErrorCode(rawValue: 10017)
 
     /// Insufficient memory resources available
-    static let memoryResourcesExceeded = ErrorCode(rawValue: 10028)
+    public static let memoryResourcesExceeded = ErrorCode(rawValue: 10028)
 
     /// Stream mirrors can not contain filtered subjects
-    static let mirrorWithSubjectFilters = ErrorCode(rawValue: 10033)
+    public static let mirrorWithSubjectFilters = ErrorCode(rawValue: 10033)
 
     /// Stream create failed with a string
-    static let streamCreate = ErrorCode(rawValue: 10049)
+    public static let streamCreate = ErrorCode(rawValue: 10049)
 
     /// Server is not a member of the cluster
-    static let clusterServerNotMember = ErrorCode(rawValue: 10044)
+    public static let clusterServerNotMember = ErrorCode(rawValue: 10044)
 
     /// No message found
-    static let noMessageFound = ErrorCode(rawValue: 10037)
+    public static let noMessageFound = ErrorCode(rawValue: 10037)
 
     /// Deliver subject not valid
-    static let snapshotDeliverSubjectInvalid = ErrorCode(rawValue: 10015)
+    public static let snapshotDeliverSubjectInvalid = ErrorCode(rawValue: 10015)
 
     /// General stream failure
-    static let streamGeneralor = ErrorCode(rawValue: 10051)
+    public static let streamGeneralor = ErrorCode(rawValue: 10051)
 
     /// Invalid stream config
-    static let streamInvalidConfig = ErrorCode(rawValue: 10052)
+    public static let streamInvalidConfig = ErrorCode(rawValue: 10052)
 
     /// Replicas > 1 not supported in non-clustered mode
-    static let streamReplicasNotSupported = ErrorCode(rawValue: 10074)
+    public static let streamReplicasNotSupported = ErrorCode(rawValue: 10074)
 
     /// Stream message delete failed
-    static let streamMessageDeleteFailed = ErrorCode(rawValue: 10057)
+    public static let streamMessageDeleteFailed = ErrorCode(rawValue: 10057)
 
     /// Peer remap failed
-    static let peerRemap = ErrorCode(rawValue: 10075)
+    public static let peerRemap = ErrorCode(rawValue: 10075)
 
     /// Stream store failed
-    static let streamStoreFailed = ErrorCode(rawValue: 10077)
+    public static let streamStoreFailed = ErrorCode(rawValue: 10077)
 
     /// Consumer config required
-    static let consumerConfigRequired = ErrorCode(rawValue: 10078)
+    public static let consumerConfigRequired = ErrorCode(rawValue: 10078)
 
     /// Consumer deliver subject has wildcards
-    static let consumerDeliverToWildcards = ErrorCode(rawValue: 10079)
+    public static let consumerDeliverToWildcards = ErrorCode(rawValue: 10079)
 
     /// Consumer in push mode can not set max waiting
-    static let consumerPushMaxWaiting = ErrorCode(rawValue: 10080)
+    public static let consumerPushMaxWaiting = ErrorCode(rawValue: 10080)
 
     /// Consumer deliver subject forms a cycle
-    static let consumerDeliverCycle = ErrorCode(rawValue: 10081)
+    public static let consumerDeliverCycle = ErrorCode(rawValue: 10081)
 
     /// Consumer requires ack policy for max ack pending
-    static let consumerMaxPendingAckPolicyRequired = ErrorCode(rawValue: 10082)
+    public static let consumerMaxPendingAckPolicyRequired = ErrorCode(rawValue: 10082)
 
     /// Consumer idle heartbeat needs to be >= 100ms
-    static let consumerSmallHeartbeat = ErrorCode(rawValue: 10083)
+    public static let consumerSmallHeartbeat = ErrorCode(rawValue: 10083)
 
     /// Consumer in pull mode requires ack policy
-    static let consumerPullRequiresAck = ErrorCode(rawValue: 10084)
+    public static let consumerPullRequiresAck = ErrorCode(rawValue: 10084)
 
     /// Consumer in pull mode requires a durable name
-    static let consumerPullNotDurable = ErrorCode(rawValue: 10085)
+    public static let consumerPullNotDurable = ErrorCode(rawValue: 10085)
 
     /// Consumer in pull mode can not have rate limit set
-    static let consumerPullWithRateLimit = ErrorCode(rawValue: 10086)
+    public static let consumerPullWithRateLimit = ErrorCode(rawValue: 10086)
 
     /// Consumer max waiting needs to be positive
-    static let consumerMaxWaitingNegative = ErrorCode(rawValue: 10087)
+    public static let consumerMaxWaitingNegative = ErrorCode(rawValue: 10087)
 
     /// Consumer idle heartbeat requires a push based consumer
-    static let consumerHeartbeatRequiresPush = ErrorCode(rawValue: 10088)
+    public static let consumerHeartbeatRequiresPush = ErrorCode(rawValue: 10088)
 
     /// Consumer flow control requires a push based consumer
-    static let consumerFlowControlRequiresPush = ErrorCode(rawValue: 10089)
+    public static let consumerFlowControlRequiresPush = ErrorCode(rawValue: 10089)
 
     /// Consumer direct requires a push based consumer
-    static let consumerDirectRequiresPush = ErrorCode(rawValue: 10090)
+    public static let consumerDirectRequiresPush = ErrorCode(rawValue: 10090)
 
     /// Consumer direct requires an ephemeral consumer
-    static let consumerDirectRequiresEphemeral = ErrorCode(rawValue: 10091)
+    public static let consumerDirectRequiresEphemeral = ErrorCode(rawValue: 10091)
 
     /// Consumer direct on a mapped consumer
-    static let consumerOnMapped = ErrorCode(rawValue: 10092)
+    public static let consumerOnMapped = ErrorCode(rawValue: 10092)
 
     /// Consumer filter subject is not a valid subset of the interest subjects
-    static let consumerFilterNotSubset = ErrorCode(rawValue: 10093)
+    public static let consumerFilterNotSubset = ErrorCode(rawValue: 10093)
 
     /// Invalid consumer policy
-    static let consumerInvalidPolicy = ErrorCode(rawValue: 10094)
+    public static let consumerInvalidPolicy = ErrorCode(rawValue: 10094)
 
     /// Failed to parse consumer sampling configuration
-    static let consumerInvalidSampling = ErrorCode(rawValue: 10095)
+    public static let consumerInvalidSampling = ErrorCode(rawValue: 10095)
 
     /// Stream not valid
-    static let streamInvalid = ErrorCode(rawValue: 10096)
+    public static let streamInvalid = ErrorCode(rawValue: 10096)
 
     /// Workqueue stream requires explicit ack
-    static let consumerWqRequiresExplicitAck = ErrorCode(rawValue: 10098)
+    public static let consumerWqRequiresExplicitAck = ErrorCode(rawValue: 10098)
 
     /// Multiple non-filtered consumers not allowed on workqueue stream
-    static let consumerWqMultipleUnfiltered = ErrorCode(rawValue: 10099)
+    public static let consumerWqMultipleUnfiltered = ErrorCode(rawValue: 10099)
 
     /// Filtered consumer not unique on workqueue stream
-    static let consumerWqConsumerNotUnique = ErrorCode(rawValue: 10100)
+    public static let consumerWqConsumerNotUnique = ErrorCode(rawValue: 10100)
 
     /// Consumer must be deliver all on workqueue stream
-    static let consumerWqConsumerNotDeliverAll = ErrorCode(rawValue: 10101)
+    public static let consumerWqConsumerNotDeliverAll = ErrorCode(rawValue: 10101)
 
     /// Consumer name is too long
-    static let consumerNameTooLong = ErrorCode(rawValue: 10102)
+    public static let consumerNameTooLong = ErrorCode(rawValue: 10102)
 
     /// Durable name can not contain token separators and wildcards
-    static let consumerBadDurableName = ErrorCode(rawValue: 10103)
+    public static let consumerBadDurableName = ErrorCode(rawValue: 10103)
 
     /// Error creating store for consumer
-    static let consumerStoreFailed = ErrorCode(rawValue: 10104)
+    public static let consumerStoreFailed = ErrorCode(rawValue: 10104)
 
     /// Consumer already exists and is still active
-    static let consumerExistingActive = ErrorCode(rawValue: 10105)
+    public static let consumerExistingActive = ErrorCode(rawValue: 10105)
 
     /// Consumer replacement durable config not the same
-    static let consumerReplacementWithDifferentName = ErrorCode(rawValue: 10106)
+    public static let consumerReplacementWithDifferentName = ErrorCode(rawValue: 10106)
 
     /// Consumer description is too long
-    static let consumerDescriptionTooLong = ErrorCode(rawValue: 10107)
+    public static let consumerDescriptionTooLong = ErrorCode(rawValue: 10107)
 
     /// Header size exceeds maximum allowed of 64k
-    static let streamHeaderExceedsMaximum = ErrorCode(rawValue: 10097)
+    public static let streamHeaderExceedsMaximum = ErrorCode(rawValue: 10097)
 
     /// Consumer with flow control also needs heartbeats
-    static let consumerWithFlowControlNeedsHeartbeats = ErrorCode(rawValue: 10108)
+    public static let consumerWithFlowControlNeedsHeartbeats = ErrorCode(rawValue: 10108)
 
     /// Invalid operation on sealed stream
-    static let streamSealed = ErrorCode(rawValue: 10109)
+    public static let streamSealed = ErrorCode(rawValue: 10109)
 
     /// Stream purge failed
-    static let streamPurgeFailed = ErrorCode(rawValue: 10110)
+    public static let streamPurgeFailed = ErrorCode(rawValue: 10110)
 
     /// Stream rollup failed
-    static let streamRollupFailed = ErrorCode(rawValue: 10111)
+    public static let streamRollupFailed = ErrorCode(rawValue: 10111)
 
     /// Invalid push consumer deliver subject
-    static let consumerInvalidDeliverSubject = ErrorCode(rawValue: 10112)
+    public static let consumerInvalidDeliverSubject = ErrorCode(rawValue: 10112)
 
     /// Account requires a stream config to have max bytes set
-    static let streamMaxBytesRequired = ErrorCode(rawValue: 10113)
+    public static let streamMaxBytesRequired = ErrorCode(rawValue: 10113)
 
     /// Consumer max request batch needs to be > 0
-    static let consumerMaxRequestBatchNegative = ErrorCode(rawValue: 10114)
+    public static let consumerMaxRequestBatchNegative = ErrorCode(rawValue: 10114)
 
     /// Consumer max request expires needs to be >= 1ms
-    static let consumerMaxRequestExpiresToSmall = ErrorCode(rawValue: 10115)
+    public static let consumerMaxRequestExpiresToSmall = ErrorCode(rawValue: 10115)
 
     /// Max deliver is required to be > length of backoff values
-    static let consumerMaxDeliverBackoff = ErrorCode(rawValue: 10116)
+    public static let consumerMaxDeliverBackoff = ErrorCode(rawValue: 10116)
 
     /// Subject details would exceed maximum allowed
-    static let streamInfoMaxSubjects = ErrorCode(rawValue: 10117)
+    public static let streamInfoMaxSubjects = ErrorCode(rawValue: 10117)
 
     /// Stream is offline
-    static let streamOffline = ErrorCode(rawValue: 10118)
+    public static let streamOffline = ErrorCode(rawValue: 10118)
 
     /// Consumer is offline
-    static let consumerOffline = ErrorCode(rawValue: 10119)
+    public static let consumerOffline = ErrorCode(rawValue: 10119)
 
     /// No jetstream default or applicable tiered limit present
-    static let noLimits = ErrorCode(rawValue: 10120)
+    public static let noLimits = ErrorCode(rawValue: 10120)
 
     /// Consumer max ack pending exceeds system limit
-    static let consumerMaxPendingAckExcess = ErrorCode(rawValue: 10121)
+    public static let consumerMaxPendingAckExcess = ErrorCode(rawValue: 10121)
 
     /// Stream max bytes exceeds account limit max stream bytes
-    static let streamMaxStreamBytesExceeded = ErrorCode(rawValue: 10122)
+    public static let streamMaxStreamBytesExceeded = ErrorCode(rawValue: 10122)
 
     /// Can not move and scale a stream in a single update
-    static let streamMoveAndScale = ErrorCode(rawValue: 10123)
+    public static let streamMoveAndScale = ErrorCode(rawValue: 10123)
 
     /// Stream move already in progress
-    static let streamMoveInProgress = ErrorCode(rawValue: 10124)
+    public static let streamMoveInProgress = ErrorCode(rawValue: 10124)
 
     /// Consumer max request batch exceeds server limit
-    static let consumerMaxRequestBatchExceeded = ErrorCode(rawValue: 10125)
+    public static let consumerMaxRequestBatchExceeded = ErrorCode(rawValue: 10125)
 
     /// Consumer config replica count exceeds parent stream
-    static let consumerReplicasExceedsStream = ErrorCode(rawValue: 10126)
+    public static let consumerReplicasExceedsStream = ErrorCode(rawValue: 10126)
 
     /// Consumer name can not contain path separators
-    static let consumerNameContainsPathSeparators = ErrorCode(rawValue: 10127)
+    public static let consumerNameContainsPathSeparators = ErrorCode(rawValue: 10127)
 
     /// Stream name can not contain path separators
-    static let streamNameContainsPathSeparators = ErrorCode(rawValue: 10128)
+    public static let streamNameContainsPathSeparators = ErrorCode(rawValue: 10128)
 
     /// Stream move not in progress
-    static let streamMoveNotInProgress = ErrorCode(rawValue: 10129)
+    public static let streamMoveNotInProgress = ErrorCode(rawValue: 10129)
 
     /// Stream name already in use, cannot restore
-    static let streamNameExistRestoreFailed = ErrorCode(rawValue: 10130)
+    public static let streamNameExistRestoreFailed = ErrorCode(rawValue: 10130)
 
     /// Consumer create request did not match filtered subject from create subject
-    static let consumerCreateFilterSubjectMismatch = ErrorCode(rawValue: 10131)
+    public static let consumerCreateFilterSubjectMismatch = ErrorCode(rawValue: 10131)
 
     /// Consumer durable and name have to be equal if both are provided
-    static let consumerCreateDurableAndNameMismatch = ErrorCode(rawValue: 10132)
+    public static let consumerCreateDurableAndNameMismatch = ErrorCode(rawValue: 10132)
 
     /// Replicas count cannot be negative
-    static let replicasCountCannotBeNegative = ErrorCode(rawValue: 10133)
+    public static let replicasCountCannotBeNegative = ErrorCode(rawValue: 10133)
 
     /// Consumer config replicas must match interest retention stream's replicas
-    static let consumerReplicasShouldMatchStream = ErrorCode(rawValue: 10134)
+    public static let consumerReplicasShouldMatchStream = ErrorCode(rawValue: 10134)
 
     /// Consumer metadata exceeds maximum size
-    static let consumerMetadataLength = ErrorCode(rawValue: 10135)
+    public static let consumerMetadataLength = ErrorCode(rawValue: 10135)
 
     /// Consumer cannot have both filter_subject and filter_subjects specified
-    static let consumerDuplicateFilterSubjects = ErrorCode(rawValue: 10136)
+    public static let consumerDuplicateFilterSubjects = ErrorCode(rawValue: 10136)
 
     /// Consumer with multiple subject filters cannot use subject based api
-    static let consumerMultipleFiltersNotAllowed = ErrorCode(rawValue: 10137)
+    public static let consumerMultipleFiltersNotAllowed = ErrorCode(rawValue: 10137)
 
     /// Consumer subject filters cannot overlap
-    static let consumerOverlappingSubjectFilters = ErrorCode(rawValue: 10138)
+    public static let consumerOverlappingSubjectFilters = ErrorCode(rawValue: 10138)
 
     /// Consumer filter in filter_subjects cannot be empty
-    static let consumerEmptyFilter = ErrorCode(rawValue: 10139)
+    public static let consumerEmptyFilter = ErrorCode(rawValue: 10139)
 
     /// Duplicate source configuration detected
-    static let sourceDuplicateDetected = ErrorCode(rawValue: 10140)
+    public static let sourceDuplicateDetected = ErrorCode(rawValue: 10140)
 
     /// Sourced stream name is invalid
-    static let sourceInvalidStreamName = ErrorCode(rawValue: 10141)
+    public static let sourceInvalidStreamName = ErrorCode(rawValue: 10141)
 
     /// Mirrored stream name is invalid
-    static let mirrorInvalidStreamName = ErrorCode(rawValue: 10142)
+    public static let mirrorInvalidStreamName = ErrorCode(rawValue: 10142)
 
     /// Source with multiple subject transforms cannot also have a single subject filter
-    static let sourceMultipleFiltersNotAllowed = ErrorCode(rawValue: 10144)
+    public static let sourceMultipleFiltersNotAllowed = ErrorCode(rawValue: 10144)
 
     /// Source subject filter is invalid
-    static let sourceInvalidSubjectFilter = ErrorCode(rawValue: 10145)
+    public static let sourceInvalidSubjectFilter = ErrorCode(rawValue: 10145)
 
     /// Source transform destination is invalid
-    static let sourceInvalidTransformDestination = ErrorCode(rawValue: 10146)
+    public static let sourceInvalidTransformDestination = ErrorCode(rawValue: 10146)
 
     /// Source filters cannot overlap
-    static let sourceOverlappingSubjectFilters = ErrorCode(rawValue: 10147)
+    public static let sourceOverlappingSubjectFilters = ErrorCode(rawValue: 10147)
 
     /// Consumer already exists
-    static let consumerAlreadyExists = ErrorCode(rawValue: 10148)
+    public static let consumerAlreadyExists = ErrorCode(rawValue: 10148)
 
     /// Consumer does not exist
-    static let consumerDoesNotExist = ErrorCode(rawValue: 10149)
+    public static let consumerDoesNotExist = ErrorCode(rawValue: 10149)
 
     /// Mirror with multiple subject transforms cannot also have a single subject filter
-    static let mirrorMultipleFiltersNotAllowed = ErrorCode(rawValue: 10150)
+    public static let mirrorMultipleFiltersNotAllowed = ErrorCode(rawValue: 10150)
 
     /// Mirror subject filter is invalid
-    static let mirrorInvalidSubjectFilter = ErrorCode(rawValue: 10151)
+    public static let mirrorInvalidSubjectFilter = ErrorCode(rawValue: 10151)
 
     /// Mirror subject filters cannot overlap
-    static let mirrorOverlappingSubjectFilters = ErrorCode(rawValue: 10152)
+    public static let mirrorOverlappingSubjectFilters = ErrorCode(rawValue: 10152)
 
     /// Consumer inactive threshold exceeds system limit
-    static let consumerInactiveThresholdExcess = ErrorCode(rawValue: 10153)
+    public static let consumerInactiveThresholdExcess = ErrorCode(rawValue: 10153)
 
 }
 
 extension ErrorCode {
     // Encoding
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }
 
     // Decoding
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let decodedValue = try container.decode(UInt64.self)
         self = ErrorCode(rawValue: decodedValue)

--- a/Sources/JetStream/Stream.swift
+++ b/Sources/JetStream/Stream.swift
@@ -64,25 +64,25 @@ public enum StreamValidationError: NatsError {
 /// `StreamInfo` contains details about the configuration and state of a stream within JetStream.
 public struct StreamInfo: Codable {
     /// The configuration settings of the stream, set upon creation or update.
-    let config: StreamConfig
+    public let config: StreamConfig
 
     /// The timestamp indicating when the stream was created.
-    let created: String
+    public let created: String
 
     /// Provides the current state of the stream including metrics such as message count and total bytes.
-    let state: StreamState
+    public let state: StreamState
 
     /// Information about the cluster to which this stream belongs, if applicable.
-    let cluster: ClusterInfo?
+    public let cluster: ClusterInfo?
 
     /// Information about another stream that this one is mirroring, if applicable.
-    let mirror: StreamSourceInfo?
+    public let mirror: StreamSourceInfo?
 
     /// A list of source streams from which this stream collects data.
-    let sources: [StreamSourceInfo]?
+    public let sources: [StreamSourceInfo]?
 
     /// The timestamp indicating when this information was gathered by the server.
-    let timeStamp: String
+    public let timeStamp: String
 
     enum CodingKeys: String, CodingKey {
         case config, created, state, cluster, mirror, sources
@@ -93,97 +93,163 @@ public struct StreamInfo: Codable {
 /// `StreamConfig` defines the configuration for a JetStream stream.
 public struct StreamConfig: Codable, Equatable {
     /// The name of the stream, required and must be unique across the JetStream account.
-    let name: String
+    public let name: String
 
     /// An optional description of the stream.
-    var description: String? = nil
+    public var description: String?
 
     /// A list of subjects that the stream is listening on, cannot be set if the stream is a mirror.
-    var subjects: [String]? = nil
+    public var subjects: [String]?
 
     /// The message retention policy for the stream, defaults to `LimitsPolicy`.
-    var retention: RetentionPolicy = .limits
+    public var retention: RetentionPolicy
 
     /// The maximum number of consumers allowed for the stream.
-    var maxConsumers: Int = -1
+    public var maxConsumers: Int
 
     /// The maximum number of messages the stream will store.
-    var maxMsgs: Int64 = -1
+    public var maxMsgs: Int64
 
     /// The maximum total size of messages the stream will store.
-    var maxBytes: Int64 = -1
+    public var maxBytes: Int64
 
     /// Defines the policy for handling messages when the stream's limits are reached.
-    var discard: DiscardPolicy = .old
+    public var discard: DiscardPolicy
 
     /// A flag to enable discarding new messages per subject when limits are reached.
-    var discardNewPerSubject: Bool? = nil
+    public var discardNewPerSubject: Bool?
 
     /// The maximum age of messages that the stream will retain.
-    var maxAge: NanoTimeInterval = NanoTimeInterval(0)
+    public var maxAge: NanoTimeInterval
 
     /// The maximum number of messages per subject that the stream will retain.
-    var maxMsgsPerSubject: Int64 = -1
+    public var maxMsgsPerSubject: Int64
 
     /// The maximum size of any single message in the stream.
-    var maxMsgSize: Int32 = -1
+    public var maxMsgSize: Int32
 
     /// Specifies the type of storage backend used for the stream (file or memory).
-    var storage: StorageType = .file
+    public var storage: StorageType
 
     /// The number of stream replicas in clustered JetStream.
-    var replicas: Int = 1
+    public var replicas: Int
 
     /// A flag to disable acknowledging messages received by this stream.
-    var noAck: Bool? = nil
+    public var noAck: Bool?
 
     /// The window within which to track duplicate messages.
-    var duplicates: NanoTimeInterval? = nil
+    public var duplicates: NanoTimeInterval?
 
     /// Used to declare where the stream should be placed via tags or an explicit cluster name.
-    var placement: Placement? = nil
+    public var placement: Placement?
 
     /// Configuration for mirroring another stream.
-    var mirror: StreamSource? = nil
+    public var mirror: StreamSource?
 
     /// A list of other streams this stream sources messages from.
-    var sources: [StreamSource]? = nil
+    public var sources: [StreamSource]?
 
     /// Whether the stream does not allow messages to be published or deleted.
-    var sealed: Bool? = nil
+    public var sealed: Bool?
 
     /// Restricts the ability to delete messages from a stream via the API.
-    var denyDelete: Bool? = nil
+    public var denyDelete: Bool?
 
     /// Restricts the ability to purge messages from a stream via the API.
-    var denyPurge: Bool? = nil
+    public var denyPurge: Bool?
 
     /// Allows the use of the Nats-Rollup header to replace all contents of a stream or subject in a stream with a single new message.
-    var allowRollup: Bool? = nil
+    public var allowRollup: Bool?
 
     /// Specifies the message storage compression algorithm.
-    var compression: StoreCompression = .none
+    public var compression: StoreCompression
 
     /// The initial sequence number of the first message in the stream.
-    var firstSeq: UInt64? = nil
+    public var firstSeq: UInt64?
 
     /// Allows applying a transformation to matching messages' subjects.
-    var subjectTransform: SubjectTransformConfig? = nil
+    public var subjectTransform: SubjectTransformConfig?
 
     /// Allows immediate republishing a message to the configured subject after it's stored.
-    var rePublish: RePublish? = nil
+    public var rePublish: RePublish?
 
     /// Enables direct access to individual messages using direct get API.
-    var allowDirect: Bool = false
+    public var allowDirect: Bool
 
     /// Enables direct access to individual messages from the origin stream using direct get API.
-    var mirrorDirect: Bool = false
+    public var mirrorDirect: Bool
 
     /// Defines limits of certain values that consumers can set.
-    var consumerLimits: StreamConsumerLimits? = nil
+    public var consumerLimits: StreamConsumerLimits?
 
     /// A set of application-defined key-value pairs for associating metadata on the stream.
-    var metadata: [String: String]? = nil
+    public var metadata: [String: String]?
+
+    public init(
+        name: String,
+        description: String? = nil,
+        subjects: [String]? = nil,
+        retention: RetentionPolicy = .limits,
+        maxConsumers: Int = -1,
+        maxMsgs: Int64 = -1,
+        maxBytes: Int64 = -1,
+        discard: DiscardPolicy = .old,
+        discardNewPerSubject: Bool? = nil,
+        maxAge: NanoTimeInterval = NanoTimeInterval(0),
+        maxMsgsPerSubject: Int64 = -1,
+        maxMsgSize: Int32 = -1,
+        storage: StorageType = .file,
+        replicas: Int = 1,
+        noAck: Bool? = nil,
+        duplicates: NanoTimeInterval? = nil,
+        placement: Placement? = nil,
+        mirror: StreamSource? = nil,
+        sources: [StreamSource]? = nil,
+        sealed: Bool? = nil,
+        denyDelete: Bool? = nil,
+        denyPurge: Bool? = nil,
+        allowRollup: Bool? = nil,
+        compression: StoreCompression = .none,
+        firstSeq: UInt64? = nil,
+        subjectTransform: SubjectTransformConfig? = nil,
+        rePublish: RePublish? = nil,
+        allowDirect: Bool = false,
+        mirrorDirect: Bool = false,
+        consumerLimits: StreamConsumerLimits? = nil,
+        metadata: [String: String]? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.subjects = subjects
+        self.retention = retention
+        self.maxConsumers = maxConsumers
+        self.maxMsgs = maxMsgs
+        self.maxBytes = maxBytes
+        self.discard = discard
+        self.discardNewPerSubject = discardNewPerSubject
+        self.maxAge = maxAge
+        self.maxMsgsPerSubject = maxMsgsPerSubject
+        self.maxMsgSize = maxMsgSize
+        self.storage = storage
+        self.replicas = replicas
+        self.noAck = noAck
+        self.duplicates = duplicates
+        self.placement = placement
+        self.mirror = mirror
+        self.sources = sources
+        self.sealed = sealed
+        self.denyDelete = denyDelete
+        self.denyPurge = denyPurge
+        self.allowRollup = allowRollup
+        self.compression = compression
+        self.firstSeq = firstSeq
+        self.subjectTransform = subjectTransform
+        self.rePublish = rePublish
+        self.allowDirect = allowDirect
+        self.mirrorDirect = mirrorDirect
+        self.consumerLimits = consumerLimits
+        self.metadata = metadata
+    }
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -266,7 +332,7 @@ public struct StreamConfig: Codable, Equatable {
 }
 
 /// `RetentionPolicy` determines how messages in a stream are retained.
-enum RetentionPolicy: String, Codable {
+public enum RetentionPolicy: String, Codable {
     /// Messages are retained until any given limit is reached (MaxMsgs, MaxBytes or MaxAge).
     case limits
 
@@ -278,7 +344,7 @@ enum RetentionPolicy: String, Codable {
 }
 
 /// `DiscardPolicy` determines how to proceed when limits of messages or bytes are reached.
-enum DiscardPolicy: String, Codable {
+public enum DiscardPolicy: String, Codable {
     /// Remove older messages to return to the limits.
     case old
 
@@ -287,7 +353,7 @@ enum DiscardPolicy: String, Codable {
 }
 
 /// `StorageType` determines how messages are stored for retention.
-enum StorageType: String, Codable {
+public enum StorageType: String, Codable {
     /// Messages are stored on disk.
     case file
 
@@ -296,33 +362,51 @@ enum StorageType: String, Codable {
 }
 
 /// `Placement` guides the placement of streams in clustered JetStream.
-struct Placement: Codable, Equatable {
+public struct Placement: Codable, Equatable {
     /// Tags used to match streams to servers in the cluster.
-    var tags: [String]? = nil
+    public var tags: [String]?
 
     /// Name of the cluster to which the stream should be assigned.
-    var cluster: String? = nil
+    public var cluster: String?
+
+    public init(tags: [String]? = nil, cluster: String? = nil) {
+        self.tags = tags
+        self.cluster = cluster
+    }
 }
 
 /// `StreamSource` defines how streams can source from other streams.
-struct StreamSource: Codable, Equatable {
+public struct StreamSource: Codable, Equatable {
     /// Name of the stream to source from.
-    let name: String
+    public let name: String
 
     /// Sequence number to start sourcing from.
-    let optStartSeq: UInt64? = nil
+    public let optStartSeq: UInt64?
 
     // Timestamp of messages to start sourcing from.
-    let optStartTime: Date? = nil
+    public let optStartTime: Date?
 
     /// Subject filter to replicate only matching messages.
-    let filterSubject: String? = nil
+    public let filterSubject: String?
 
     /// Transforms applied to subjects.
-    let subjectTransforms: [SubjectTransformConfig]? = nil
+    public let subjectTransforms: [SubjectTransformConfig]?
 
     /// Configuration for external stream sources.
-    let external: ExternalStream? = nil
+    public let external: ExternalStream?
+
+    public init(
+        name: String, optStartSeq: UInt64? = nil, optStartTime: Date? = nil,
+        filterSubject: String? = nil, subjectTransforms: [SubjectTransformConfig]? = nil,
+        external: ExternalStream? = nil
+    ) {
+        self.name = name
+        self.optStartSeq = optStartSeq
+        self.optStartTime = optStartTime
+        self.filterSubject = filterSubject
+        self.subjectTransforms = subjectTransforms
+        self.external = external
+    }
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -335,13 +419,18 @@ struct StreamSource: Codable, Equatable {
 }
 
 /// `ExternalStream` qualifies access to a stream source in another account or JetStream domain.
-struct ExternalStream: Codable, Equatable {
+public struct ExternalStream: Codable, Equatable {
 
     /// Subject prefix for importing API subjects.
-    let apiPrefix: String
+    public let apiPrefix: String
 
     /// Delivery subject for push consumers.
-    let deliverPrefix: String
+    public let deliverPrefix: String
+
+    public init(apiPrefix: String, deliverPrefix: String) {
+        self.apiPrefix = apiPrefix
+        self.deliverPrefix = deliverPrefix
+    }
 
     enum CodingKeys: String, CodingKey {
         case apiPrefix = "api"
@@ -350,7 +439,7 @@ struct ExternalStream: Codable, Equatable {
 }
 
 /// `StoreCompression` specifies the message storage compression algorithm.
-enum StoreCompression: String, Codable {
+public enum StoreCompression: String, Codable {
     /// No compression is applied.
     case none
 
@@ -359,12 +448,17 @@ enum StoreCompression: String, Codable {
 }
 
 /// `SubjectTransformConfig` configures subject transformations for incoming messages.
-struct SubjectTransformConfig: Codable, Equatable {
+public struct SubjectTransformConfig: Codable, Equatable {
     /// Subject pattern to match incoming messages.
-    let source: String
+    public let source: String
 
     /// Subject pattern to remap the subject to.
-    let destination: String
+    public let destination: String
+
+    public init(source: String, destination: String) {
+        self.source = source
+        self.destination = destination
+    }
 
     enum CodingKeys: String, CodingKey {
         case source = "src"
@@ -373,15 +467,21 @@ struct SubjectTransformConfig: Codable, Equatable {
 }
 
 /// `RePublish` configures republishing of messages once they are committed to a stream.
-struct RePublish: Codable, Equatable {
+public struct RePublish: Codable, Equatable {
     /// Subject pattern to match incoming messages.
-    let source: String? = nil
+    public let source: String?
 
     /// Subject pattern to republish the subject to.
-    let destination: String
+    public let destination: String
 
     /// Flag to indicate if only headers should be republished.
-    let headersOnly: Bool? = nil
+    public let headersOnly: Bool?
+
+    public init(destination: String, source: String? = nil, headersOnly: Bool? = nil) {
+        self.destination = destination
+        self.source = source
+        self.headersOnly = headersOnly
+    }
 
     enum CodingKeys: String, CodingKey {
         case source = "src"
@@ -391,12 +491,17 @@ struct RePublish: Codable, Equatable {
 }
 
 /// `StreamConsumerLimits` defines the limits for a consumer on a stream.
-struct StreamConsumerLimits: Codable, Equatable {
+public struct StreamConsumerLimits: Codable, Equatable {
     /// Duration to clean up the consumer if inactive.
-    var inactiveThreshold: NanoTimeInterval? = nil
+    public var inactiveThreshold: NanoTimeInterval?
 
     /// Maximum number of outstanding unacknowledged messages.
-    var maxAckPending: Int? = nil
+    public var maxAckPending: Int?
+
+    public init(inactiveThreshold: NanoTimeInterval? = nil, maxAckPending: Int? = nil) {
+        self.inactiveThreshold = inactiveThreshold
+        self.maxAckPending = maxAckPending
+    }
 
     enum CodingKeys: String, CodingKey {
         case inactiveThreshold = "inactive_threshold"
@@ -407,37 +512,37 @@ struct StreamConsumerLimits: Codable, Equatable {
 /// `StreamState` represents the state of a JetStream stream at the time of the request.
 public struct StreamState: Codable {
     /// Number of messages stored in the stream.
-    let messages: UInt64
+    public let messages: UInt64
 
     /// Number of bytes stored in the stream.
-    let bytes: UInt64
+    public let bytes: UInt64
 
     /// Sequence number of the first message.
-    let firstSeq: UInt64
+    public let firstSeq: UInt64
 
     /// Timestamp of the first message.
-    let firstTime: String
+    public let firstTime: String
 
     /// Sequence number of the last message.
-    let lastSeq: UInt64
+    public let lastSeq: UInt64
 
     /// Timestamp of the last message.
-    let lastTime: String
+    public let lastTime: String
 
     /// Number of consumers on the stream.
-    let consumers: Int
+    public let consumers: Int
 
     /// Sequence numbers of deleted messages.
-    let deleted: [UInt64]?
+    public let deleted: [UInt64]?
 
     /// Number of messages deleted causing gaps in sequence numbers.
-    let numDeleted: Int?
+    public let numDeleted: Int?
 
     /// Number of unique subjects received messages.
-    let numSubjects: UInt64?
+    public let numSubjects: UInt64?
 
     /// Message count per subject.
-    let subjects: [String: UInt64]?
+    public let subjects: [String: UInt64]?
 
     enum CodingKeys: String, CodingKey {
         case messages
@@ -457,31 +562,31 @@ public struct StreamState: Codable {
 /// `ClusterInfo` contains details about the cluster to which a stream belongs.
 public struct ClusterInfo: Codable {
     /// The name of the cluster.
-    let name: String?
+    public let name: String?
 
     /// The server name of the RAFT leader within the cluster.
-    let leader: String?
+    public let leader: String?
 
     /// A list of peers that are part of the cluster.
-    let replicas: [PeerInfo]?
+    public let replicas: [PeerInfo]?
 }
 
 /// `StreamSourceInfo` provides information about an upstream stream source or mirror.
 public struct StreamSourceInfo: Codable {
     /// The name of the stream that is being replicated or mirrored.
-    let name: String
+    public let name: String
 
     /// The lag in messages between this stream and the stream it mirrors or sources from.
-    let lag: UInt64
+    public let lag: UInt64
 
     /// The time since the last activity was detected for this stream.
-    let active: NanoTimeInterval
+    public let active: NanoTimeInterval
 
     /// The subject filter used to replicate messages with matching subjects.
-    let filterSubject: String?
+    public let filterSubject: String?
 
     /// A list of subject transformations applied to messages as they are sourced.
-    let subjectTransforms: [SubjectTransformConfig]?
+    public let subjectTransforms: [SubjectTransformConfig]?
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -495,19 +600,19 @@ public struct StreamSourceInfo: Codable {
 /// `PeerInfo` provides details about the peers in a cluster that support the stream or consumer.
 public struct PeerInfo: Codable {
     /// The server name of the peer within the cluster.
-    let name: String
+    public let name: String
 
     /// Indicates if the peer is currently synchronized and up-to-date with the leader.
-    let current: Bool
+    public let current: Bool
 
     /// Indicates if the peer is considered offline by the cluster.
-    let offline: Bool?
+    public let offline: Bool?
 
     /// The time duration since this peer was last active.
-    let active: NanoTimeInterval
+    public let active: NanoTimeInterval
 
     /// The number of uncommitted operations this peer is lagging behind the leader.
-    let lag: UInt64?
+    public let lag: UInt64?
 
     enum CodingKeys: String, CodingKey {
         case name

--- a/Sources/Nats/NatsClient/NatsClient.swift
+++ b/Sources/Nats/NatsClient/NatsClient.swift
@@ -18,7 +18,7 @@ import NIO
 import NIOFoundationCompat
 import Nuid
 
-var logger = Logger(label: "Nats")
+public var logger = Logger(label: "Nats")
 
 /// NatsClient connection states
 public enum NatsState {

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -835,7 +835,7 @@ public enum NatsEvent {
     case lameDuckMode
     case error(NatsError)
 
-    func kind() -> NatsEventKind {
+    public func kind() -> NatsEventKind {
         switch self {
         case .connected:
             return .connected

--- a/Sources/Nats/NatsError.swift
+++ b/Sources/Nats/NatsError.swift
@@ -15,8 +15,8 @@ public protocol NatsError: Error {
     var description: String { get }
 }
 
-struct NatsServerError: NatsError {
-    var description: String
+public struct NatsServerError: NatsError {
+    public var description: String
     var normalizedError: String {
         return description.trimWhitespacesAndApostrophes().lowercased()
     }
@@ -25,22 +25,22 @@ struct NatsServerError: NatsError {
     }
 }
 
-struct NatsParserError: NatsError {
-    var description: String
+public struct NatsParserError: NatsError {
+    public var description: String
     init(_ description: String) {
         self.description = description
     }
 }
 
-struct NatsClientError: NatsError {
-    var description: String
+public struct NatsClientError: NatsError {
+    public var description: String
     init(_ description: String) {
         self.description = description
     }
 }
 
-struct NatsConfigError: NatsError {
-    var description: String
+public struct NatsConfigError: NatsError {
+    public var description: String
     init(_ description: String) {
         self.description = description
     }

--- a/Sources/Nats/NatsHeaders.swift
+++ b/Sources/Nats/NatsHeaders.swift
@@ -109,7 +109,7 @@ public struct NatsHeaderMap: Equatable {
 }
 
 extension NatsHeaderMap {
-    subscript(name: NatsHeaderName) -> NatsHeaderValue? {
+    public subscript(name: NatsHeaderName) -> NatsHeaderValue? {
         get {
             return get(name)
         }

--- a/Tests/JetStreamTests/Integration/JetStreamTests.swift
+++ b/Tests/JetStreamTests/Integration/JetStreamTests.swift
@@ -11,14 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import JetStream
 import Logging
 import NIO
 import Nats
 import NatsServer
 import XCTest
-
-@testable import JetStream
-@testable import Nats
 
 class JetStreamTests: XCTestCase {
 
@@ -27,6 +25,8 @@ class JetStreamTests: XCTestCase {
         ("testRequest", testRequest),
         ("testStreamCRUD", testStreamCRUD),
         ("testStreamConfig", testStreamConfig),
+        ("testStreamInfo", testStreamInfo),
+        ("testListStreams", testListStreams),
     ]
 
     var natsServer = NatsServer()

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -13,10 +13,9 @@
 
 import Logging
 import NIO
+import Nats
 import NatsServer
 import XCTest
-
-@testable import Nats
 
 class CoreNatsTests: XCTestCase {
 

--- a/Tests/NatsTests/Integration/EventsTests.swift
+++ b/Tests/NatsTests/Integration/EventsTests.swift
@@ -13,10 +13,9 @@
 
 import Foundation
 import Logging
+import Nats
 import NatsServer
 import XCTest
-
-@testable import Nats
 
 class TestNatsEvents: XCTestCase {
 

--- a/Tests/NatsTests/Integration/MessageWithHeadersTests.swift
+++ b/Tests/NatsTests/Integration/MessageWithHeadersTests.swift
@@ -13,10 +13,9 @@
 
 import Foundation
 import Logging
+import Nats
 import NatsServer
 import XCTest
-
-@testable import Nats
 
 class TestMessageWithHeadersTests: XCTestCase {
 


### PR DESCRIPTION
Added public access modifiers in several places:
- JetStream structs (StreamConfig, StreamInfo etc.)
- JetStream context methods (`wait()` and `request()`). I am not sure if `request()` should be public though, so that needs to be discussed.
- logger - we should think of a better approach to logger configuration instead of global public var, but that can be done as a separate issue
- several Error structs

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>