### PR TITLE
Add fetching individual messages from stream

### DIFF
--- a/Sources/Nats/Extensions/Data+Parser.swift
+++ b/Sources/Nats/Extensions/Data+Parser.swift
@@ -19,7 +19,7 @@ extension Data {
     private static let crlf = Data([cr, lf])
     private static var currentNum = 0
     private static var errored = false
-    private static let versionLinePrefix = "NATS/1.0"
+    internal static let versionLinePrefix = "NATS/1.0"
 
     func removePrefix(_ prefix: Data) -> Data {
         guard self.starts(with: prefix) else { return self }
@@ -152,41 +152,10 @@ extension Data {
 
                     let headersData = self[headersStartIndex..<headersEndIndex]
                     if let headersString = String(data: headersData, encoding: .utf8) {
-                        let headersArray = headersString.split(separator: "\r\n")
-                        let versionLine = headersArray[0]
-                        guard versionLine.hasPrefix(Data.versionLinePrefix) else {
-                            throw NatsParserError(
-                                "header version line does not begin with `NATS/1.0`")
-                        }
-                        let versionLineSuffix =
-                            versionLine
-                            .dropFirst(Data.versionLinePrefix.count)
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-                        // handle inlines status and description
-                        if versionLineSuffix.count > 0 {
-                            let statusAndDesc = versionLineSuffix.split(
-                                separator: " ", maxSplits: 1)
-                            guard let status = StatusCode(statusAndDesc[0]) else {
-                                throw NatsParserError("could not parse status parameter")
-                            }
-                            msg.status = status
-                            if statusAndDesc.count > 1 {
-                                msg.description = String(statusAndDesc[1])
-                            }
-                        }
-
-                        for header in headersArray.dropFirst() {
-                            let headerParts = header.split(separator: ":")
-                            if headerParts.count == 2 {
-                                headers.append(
-                                    try NatsHeaderName(String(headerParts[0])),
-                                    NatsHeaderValue(String(headerParts[1])))
-                            } else {
-                                logger.error("Error parsing header: \(header)")
-                            }
-                        }
+                        headers = try NatsHeaderMap(from: headersString)
                     }
+                    msg.status = headers.status
+                    msg.description = headers.description
                     msg.headers = headers
 
                     if var payload = payload {

--- a/Tests/JetStreamTests/Integration/JetStreamTests.swift
+++ b/Tests/JetStreamTests/Integration/JetStreamTests.swift
@@ -27,8 +27,8 @@ class JetStreamTests: XCTestCase {
         ("testStreamConfig", testStreamConfig),
         ("testStreamInfo", testStreamInfo),
         ("testListStreams", testListStreams),
-        ("testGetMsg", testGetMsg),
-        ("testGetMsgDirect", testGetMsgDirect),
+        ("testGetMessage", testGetMessage),
+        ("testGetMessageDirect", testGetMessageDirect),
     ]
 
     var natsServer = NatsServer()
@@ -313,7 +313,7 @@ class JetStreamTests: XCTestCase {
         XCTAssertEqual(i, 0)
     }
 
-    func testGetMsg() async throws {
+    func testGetMessage() async throws {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
@@ -339,31 +339,31 @@ class JetStreamTests: XCTestCase {
         }
 
         // get by sequence
-        var msg = try await stream.getMsg(sequence: 50)
+        var msg = try await stream.getMessage(sequence: 50)
         XCTAssertEqual(msg!.payload, "50".data(using: .utf8)!)
 
         // get by sequence and subject
-        msg = try await stream.getMsg(sequence: 50, subject: "foo.B")
+        msg = try await stream.getMessage(sequence: 50, subject: "foo.B")
         // msg with sequence 50 is on subject foo.A, so we expect the next message which should be on foo.B
         XCTAssertEqual(msg!.payload, "51".data(using: .utf8)!)
         XCTAssertEqual(msg!.headers, hm)
 
         // get first message from a subject
-        msg = try await stream.getMsg(firstForSubject: "foo.A")
+        msg = try await stream.getMessage(firstForSubject: "foo.A")
         XCTAssertEqual(msg!.payload, "2".data(using: .utf8)!)
         XCTAssertEqual(msg!.headers, hm)
 
         // get last message from subject
-        msg = try await stream.getMsg(lastForSubject: "foo.B")
+        msg = try await stream.getMessage(lastForSubject: "foo.B")
         XCTAssertEqual(msg!.payload, "99".data(using: .utf8)!)
         XCTAssertEqual(msg!.headers, hm)
 
         // message not found
-        msg = try await stream.getMsg(sequence: 200)
+        msg = try await stream.getMessage(sequence: 200)
         XCTAssertNil(msg)
     }
 
-    func testGetMsgDirect() async throws {
+    func testGetMessageDirect() async throws {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
@@ -389,24 +389,24 @@ class JetStreamTests: XCTestCase {
         }
 
         // get by sequence
-        var msg = try await stream.getMsgDirect(sequence: 50)
+        var msg = try await stream.getMessageDirect(sequence: 50)
         XCTAssertEqual(msg!.payload, "50".data(using: .utf8)!)
 
         // get by sequence and subject
-        msg = try await stream.getMsgDirect(sequence: 50, subject: "foo.B")
+        msg = try await stream.getMessageDirect(sequence: 50, subject: "foo.B")
         // msg with sequence 50 is on subject foo.A, so we expect the next message which should be on foo.B
         XCTAssertEqual(msg!.payload, "51".data(using: .utf8)!)
 
         // get first message from a subject
-        msg = try await stream.getMsgDirect(firstForSubject: "foo.A")
+        msg = try await stream.getMessageDirect(firstForSubject: "foo.A")
         XCTAssertEqual(msg!.payload, "2".data(using: .utf8)!)
 
         // get last message from subject
-        msg = try await stream.getMsgDirect(lastForSubject: "foo.B")
+        msg = try await stream.getMessageDirect(lastForSubject: "foo.B")
         XCTAssertEqual(msg!.payload, "99".data(using: .utf8)!)
 
         // message not found
-        msg = try await stream.getMsgDirect(sequence: 200)
+        msg = try await stream.getMessageDirect(sequence: 200)
         XCTAssertNil(msg)
     }
 }

--- a/Tests/JetStreamTests/Integration/JetStreamTests.swift
+++ b/Tests/JetStreamTests/Integration/JetStreamTests.swift
@@ -27,6 +27,8 @@ class JetStreamTests: XCTestCase {
         ("testStreamConfig", testStreamConfig),
         ("testStreamInfo", testStreamInfo),
         ("testListStreams", testListStreams),
+        ("testGetMsg", testGetMsg),
+        ("testGetMsgDirect", testGetMsgDirect),
     ]
 
     var natsServer = NatsServer()
@@ -309,5 +311,108 @@ class JetStreamTests: XCTestCase {
             i += 1
         }
         XCTAssertEqual(i, 0)
+    }
+
+    func testGetMsg() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .debug
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+
+        let cfg = StreamConfig(name: "STREAM", subjects: ["foo.*"])
+        let stream = try await ctx.createStream(cfg: cfg)
+
+        var hm = NatsHeaderMap()
+        hm[try! NatsHeaderName("foo")] = NatsHeaderValue("bar")
+        hm.append(try! NatsHeaderName("foo"), NatsHeaderValue("baz"))
+        hm[try! NatsHeaderName("key")] = NatsHeaderValue("val")
+        for i in 1...100 {
+            let msg = "\(i)".data(using: .utf8)!
+            let subj = i % 2 == 0 ? "foo.A" : "foo.B"
+            let ack = try await ctx.publish(subj, message: msg, headers: hm)
+            _ = try await ack.wait()
+        }
+
+        // get by sequence
+        var msg = try await stream.getMsg(sequence: 50)
+        XCTAssertEqual(msg.payload, "50".data(using: .utf8)!)
+
+        // get by sequence and subject
+        msg = try await stream.getMsg(sequence: 50, subject: "foo.B")
+        // msg with sequence 50 is on subject foo.A, so we expect the next message which should be on foo.B
+        XCTAssertEqual(msg.payload, "51".data(using: .utf8)!)
+        XCTAssertEqual(msg.headers, hm)
+
+        // get first message from a subject
+        msg = try await stream.getMsg(firstForSubject: "foo.A")
+        XCTAssertEqual(msg.payload, "2".data(using: .utf8)!)
+        XCTAssertEqual(msg.headers, hm)
+
+        // get last message from subject
+        msg = try await stream.getMsg(lastForSubject: "foo.B")
+        XCTAssertEqual(msg.payload, "99".data(using: .utf8)!)
+        XCTAssertEqual(msg.headers, hm)
+
+        // message not found
+        do {
+            _ = try await stream.getMsg(sequence: 200)
+        } catch let err as JetStreamError {
+            XCTAssertEqual(err.errorCode, .noMessageFound)
+        }
+    }
+
+    func testGetMsgDirect() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .debug
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+
+        let cfg = StreamConfig(name: "STREAM", subjects: ["foo.*"], allowDirect: true)
+        let stream = try await ctx.createStream(cfg: cfg)
+
+        var hm = NatsHeaderMap()
+        hm[try! NatsHeaderName("foo")] = NatsHeaderValue("bar")
+        hm.append(try! NatsHeaderName("foo"), NatsHeaderValue("baz"))
+        hm[try! NatsHeaderName("key")] = NatsHeaderValue("val")
+        for i in 1...100 {
+            let msg = "\(i)".data(using: .utf8)!
+            let subj = i % 2 == 0 ? "foo.A" : "foo.B"
+            let ack = try await ctx.publish(subj, message: msg, headers: hm)
+            _ = try await ack.wait()
+        }
+
+        // get by sequence
+        var msg = try await stream.getMsgDirect(sequence: 50)
+        XCTAssertEqual(msg.payload, "50".data(using: .utf8)!)
+
+        // get by sequence and subject
+        msg = try await stream.getMsgDirect(sequence: 50, subject: "foo.B")
+        // msg with sequence 50 is on subject foo.A, so we expect the next message which should be on foo.B
+        XCTAssertEqual(msg.payload, "51".data(using: .utf8)!)
+
+        // get first message from a subject
+        msg = try await stream.getMsgDirect(firstForSubject: "foo.A")
+        XCTAssertEqual(msg.payload, "2".data(using: .utf8)!)
+
+        // get last message from subject
+        msg = try await stream.getMsgDirect(lastForSubject: "foo.B")
+        XCTAssertEqual(msg.payload, "99".data(using: .utf8)!)
+
+        // message not found
+        do {
+            msg = try await stream.getMsgDirect(sequence: 200)
+        } catch let err as JetStreamDirectGetError {
+            XCTAssertEqual(err, .msgNotFound)
+        }
     }
 }

--- a/Tests/JetStreamTests/Integration/JetStreamTests.swift
+++ b/Tests/JetStreamTests/Integration/JetStreamTests.swift
@@ -340,30 +340,27 @@ class JetStreamTests: XCTestCase {
 
         // get by sequence
         var msg = try await stream.getMsg(sequence: 50)
-        XCTAssertEqual(msg.payload, "50".data(using: .utf8)!)
+        XCTAssertEqual(msg!.payload, "50".data(using: .utf8)!)
 
         // get by sequence and subject
         msg = try await stream.getMsg(sequence: 50, subject: "foo.B")
         // msg with sequence 50 is on subject foo.A, so we expect the next message which should be on foo.B
-        XCTAssertEqual(msg.payload, "51".data(using: .utf8)!)
-        XCTAssertEqual(msg.headers, hm)
+        XCTAssertEqual(msg!.payload, "51".data(using: .utf8)!)
+        XCTAssertEqual(msg!.headers, hm)
 
         // get first message from a subject
         msg = try await stream.getMsg(firstForSubject: "foo.A")
-        XCTAssertEqual(msg.payload, "2".data(using: .utf8)!)
-        XCTAssertEqual(msg.headers, hm)
+        XCTAssertEqual(msg!.payload, "2".data(using: .utf8)!)
+        XCTAssertEqual(msg!.headers, hm)
 
         // get last message from subject
         msg = try await stream.getMsg(lastForSubject: "foo.B")
-        XCTAssertEqual(msg.payload, "99".data(using: .utf8)!)
-        XCTAssertEqual(msg.headers, hm)
+        XCTAssertEqual(msg!.payload, "99".data(using: .utf8)!)
+        XCTAssertEqual(msg!.headers, hm)
 
         // message not found
-        do {
-            _ = try await stream.getMsg(sequence: 200)
-        } catch let err as JetStreamError {
-            XCTAssertEqual(err.errorCode, .noMessageFound)
-        }
+        msg = try await stream.getMsg(sequence: 200)
+        XCTAssertNil(msg)
     }
 
     func testGetMsgDirect() async throws {
@@ -393,26 +390,23 @@ class JetStreamTests: XCTestCase {
 
         // get by sequence
         var msg = try await stream.getMsgDirect(sequence: 50)
-        XCTAssertEqual(msg.payload, "50".data(using: .utf8)!)
+        XCTAssertEqual(msg!.payload, "50".data(using: .utf8)!)
 
         // get by sequence and subject
         msg = try await stream.getMsgDirect(sequence: 50, subject: "foo.B")
         // msg with sequence 50 is on subject foo.A, so we expect the next message which should be on foo.B
-        XCTAssertEqual(msg.payload, "51".data(using: .utf8)!)
+        XCTAssertEqual(msg!.payload, "51".data(using: .utf8)!)
 
         // get first message from a subject
         msg = try await stream.getMsgDirect(firstForSubject: "foo.A")
-        XCTAssertEqual(msg.payload, "2".data(using: .utf8)!)
+        XCTAssertEqual(msg!.payload, "2".data(using: .utf8)!)
 
         // get last message from subject
         msg = try await stream.getMsgDirect(lastForSubject: "foo.B")
-        XCTAssertEqual(msg.payload, "99".data(using: .utf8)!)
+        XCTAssertEqual(msg!.payload, "99".data(using: .utf8)!)
 
         // message not found
-        do {
-            msg = try await stream.getMsgDirect(sequence: 200)
-        } catch let err as JetStreamDirectGetError {
-            XCTAssertEqual(err, .msgNotFound)
-        }
+        msg = try await stream.getMsgDirect(sequence: 200)
+        XCTAssertNil(msg)
     }
 }


### PR DESCRIPTION
- Added `getMsg` and `getMsgDirect` with all optional variants (seq, next, last)
- Moved parsing headers from `Data+Parser.swift` to `NatsHeaders.swift` to be able to parse headers returned when fetching messages

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)