### PR TITLE
Refactor core nats errors

### DIFF
--- a/Sources/JetStream/JetStreamContext.swift
+++ b/Sources/JetStream/JetStreamContext.swift
@@ -99,14 +99,14 @@ public struct AckFuture {
                     if let msg = result {
                         group.cancelAll()
                         if let status = msg.status, status == StatusCode.noResponders {
-                            throw NatsRequestError.noResponders
+                            throw NatsError.RequestError.noResponders
                         }
                         return msg
                     } else {
                         group.cancelAll()
                         try await sub.unsubscribe()
                         // if result is empty, time out
-                        throw NatsRequestError.timeout
+                        throw NatsError.RequestError.timeout
                     }
                 }
 
@@ -136,14 +136,14 @@ public struct AckFuture {
 
     }
 }
-public struct JetStreamPublishError: NatsError {
+public struct JetStreamPublishError: Error {
     public var description: String
     init(_ description: String) {
         self.description = description
     }
 }
 
-public struct JetStreamRequestError: NatsError {
+public struct JetStreamRequestError: Error {
     public var description: String
     init(_ description: String) {
         self.description = description

--- a/Sources/JetStream/Stream.swift
+++ b/Sources/JetStream/Stream.swift
@@ -399,7 +399,7 @@ public class Stream {
     }
 }
 
-public enum JetStreamDirectGetError: NatsError, Equatable {
+public enum JetStreamDirectGetError: Error, Equatable {
     case msgNotFound
     case invalidResponse(String)
     case errorResponse(StatusCode, String?)
@@ -421,7 +421,7 @@ public enum JetStreamDirectGetError: NatsError, Equatable {
 }
 
 /// Returned when a provided ``StreamConfig`` is not valid.
-public enum StreamValidationError: NatsError, Equatable {
+public enum StreamValidationError: Error, Equatable {
     case nameRequired
     case invalidCharacterFound(String)
 

--- a/Sources/Nats/BatchBuffer.swift
+++ b/Sources/Nats/BatchBuffer.swift
@@ -31,6 +31,10 @@ extension BatchBuffer {
             return self.buffer.readableBytes
         }
 
+        mutating func clear() {
+            buffer.clear()
+        }
+
         mutating func getWriteBuffer() -> ByteBuffer {
             var writeBuffer = allocator.buffer(capacity: buffer.readableBytes)
             writeBuffer.writeBytes(buffer.readableBytesView)
@@ -105,10 +109,11 @@ internal class BatchBuffer {
                     }
                     state.waitingPromises.removeAll()
                 case .failure(let error):
-                    for promise in state.waitingPromises {
-                        promise.1.resume(throwing: error)
+                    for (_, continuation) in state.waitingPromises {
+                        continuation.resume(throwing: error)
                     }
                     state.waitingPromises.removeAll()
+                    state.clear()
                 }
 
                 // Check if there are any pending flushes

--- a/Sources/Nats/HTTPUpgradeRequestHandler.swift
+++ b/Sources/Nats/HTTPUpgradeRequestHandler.swift
@@ -93,7 +93,8 @@ internal final class HTTPUpgradeRequestHandler: ChannelInboundHandler, Removable
         let clientResponse = self.unwrapInboundIn(data)
         switch clientResponse {
         case .head(let responseHead):
-            self.upgradePromise.fail(NatsError.ClientError.other("ws error \(responseHead)"))
+            self.upgradePromise.fail(
+                NatsError.ClientError.invalidConnection("ws error \(responseHead)"))
         case .body: break
         case .end:
             context.close(promise: nil)

--- a/Sources/Nats/HTTPUpgradeRequestHandler.swift
+++ b/Sources/Nats/HTTPUpgradeRequestHandler.swift
@@ -93,8 +93,7 @@ internal final class HTTPUpgradeRequestHandler: ChannelInboundHandler, Removable
         let clientResponse = self.unwrapInboundIn(data)
         switch clientResponse {
         case .head(let responseHead):
-            //let error = WebSocketClient.Error.invalidResponseStatus(responseHead)
-            self.upgradePromise.fail(NatsClientError("ws error \(responseHead)"))
+            self.upgradePromise.fail(NatsError.ClientError.other("ws error \(responseHead)"))
         case .body: break
         case .end:
             context.close(promise: nil)

--- a/Sources/Nats/NatsClient/NatsClient+Events.swift
+++ b/Sources/Nats/NatsClient/NatsClient+Events.swift
@@ -14,6 +14,14 @@
 import Foundation
 
 extension NatsClient {
+
+    /// Registers a callback for given event types.
+    ///
+    /// - Parameters:
+    ///   - events: an array of ``NatsEventKind`` for which the handler will be invoked.
+    ///   - handler: a callback invoked upon triggering a specific event.
+    ///
+    /// - Returns an ID of the registered listener which can be used to disable it.
     @discardableResult
     public func on(_ events: [NatsEventKind], _ handler: @escaping (NatsEvent) -> Void) -> String {
         guard let connectionHandler = self.connectionHandler else {
@@ -22,6 +30,13 @@ extension NatsClient {
         return connectionHandler.addListeners(for: events, using: handler)
     }
 
+    /// Registers a callback for given event type.
+    ///
+    /// - Parameters:
+    ///   - events: a ``NatsEventKind`` for which the handler will be invoked.
+    ///   - handler: a callback invoked upon triggering a specific event.
+    ///
+    /// - Returns an ID of the registered listener which can be used to disable it.
     @discardableResult
     public func on(_ event: NatsEventKind, _ handler: @escaping (NatsEvent) -> Void) -> String {
         guard let connectionHandler = self.connectionHandler else {
@@ -30,7 +45,10 @@ extension NatsClient {
         return connectionHandler.addListeners(for: [event], using: handler)
     }
 
-    func off(_ id: String) {
+    /// Disables the event listener.
+    ///
+    /// - Parameter id: an ID of a listener to be disabled (returned when creating it).
+    public func off(_ id: String) {
         guard let connectionHandler = self.connectionHandler else {
             return
         }

--- a/Sources/Nats/NatsClient/NatsClient.swift
+++ b/Sources/Nats/NatsClient/NatsClient.swift
@@ -82,7 +82,7 @@ extension NatsClient {
 
     /// Connects to a NATS server using configuration provided via ``NatsClientOptions``.
     /// If ``NatsClientOptions/retryOnfailedConnect()`` is used, `connect()`
-    /// will not wait until the connection is but rather return immediatelly.
+    /// will not wait until the connection is established but rather return immediatelly.
     ///
     /// - Throws:
     ///  - ``NatsError/ConnectError/invalidConfig(_:)`` if the provided configuration is invalid

--- a/Sources/Nats/NatsClient/NatsClientOptions.swift
+++ b/Sources/Nats/NatsClient/NatsClientOptions.swift
@@ -33,31 +33,40 @@ public class NatsClientOptions {
 
     public init() {}
 
+    /// A list of server urls that a client can connect to.
     public func urls(_ urls: [URL]) -> NatsClientOptions {
         self.urls = urls
         return self
     }
 
+    /// A single url that the client can connect to.
     public func url(_ url: URL) -> NatsClientOptions {
         self.urls = [url]
         return self
     }
 
+    /// The interval with which the client will send pings to NATS server.
+    /// Defaults to 60s.
     public func pingInterval(_ pingInterval: TimeInterval) -> NatsClientOptions {
         self.pingInterval = pingInterval
         return self
     }
 
+    /// Wait time between reconnect attempts.
+    /// Defaults to 2s.
     public func reconnectWait(_ reconnectWait: TimeInterval) -> NatsClientOptions {
         self.reconnectWait = reconnectWait
         return self
     }
 
+    /// Maximum number of reconnect attempts after each disconnect.
+    /// Defaults to unlimited.
     public func maxReconnects(_ maxReconnects: Int) -> NatsClientOptions {
         self.maxReconnects = maxReconnects
         return self
     }
 
+    /// Username and password used to connect to the server.
     public func usernameAndPassword(_ username: String, _ password: String) -> NatsClientOptions {
         if self.auth == nil {
             self.auth = Auth(user: username, password: password)
@@ -68,6 +77,7 @@ public class NatsClientOptions {
         return self
     }
 
+    /// Token used for token auth to NATS server.
     public func token(_ token: String) -> NatsClientOptions {
         if self.auth == nil {
             self.auth = Auth(token: token)
@@ -77,6 +87,7 @@ public class NatsClientOptions {
         return self
     }
 
+    /// The location of a credentials file containing user JWT and Nkey seed.
     public func credentialsFile(_ credentials: URL) -> NatsClientOptions {
         if self.auth == nil {
             self.auth = Auth.fromCredentials(credentials)
@@ -86,6 +97,8 @@ public class NatsClientOptions {
         return self
     }
 
+    /// The location of a public nkey file.
+    /// This and ``NatsClientOptions/nkey(_:)`` are mutually exclusive.
     public func nkeyFile(_ nkey: URL) -> NatsClientOptions {
         if self.auth == nil {
             self.auth = Auth.fromNkey(nkey)
@@ -94,6 +107,9 @@ public class NatsClientOptions {
         }
         return self
     }
+
+    /// Public nkey.
+    /// This and ``NatsClientOptions/nkeyFile(_:)`` are mutually exclusive.
     public func nkey(_ nkey: String) -> NatsClientOptions {
         if self.auth == nil {
             self.auth = Auth.fromNkey(nkey)
@@ -103,32 +119,45 @@ public class NatsClientOptions {
         return self
     }
 
+    /// Indicates whether the client requires an SSL connection.
     public func requireTls() -> NatsClientOptions {
         self.withTls = true
         return self
     }
 
+    /// Indicates whether the client will attempt to perform a TLS handshake first, that is
+    /// before receiving the INFO protocol. This requires the server to also be
+    /// configured with such option, otherwise the connection will fail.
     public func withTlsFirst() -> NatsClientOptions {
         self.tlsFirst = true
         return self
     }
 
+    /// The location of a root CAs file.
     public func rootCertificates(_ rootCertificate: URL) -> NatsClientOptions {
         self.rootCertificate = rootCertificate
         return self
     }
 
+    /// The location of a client cert file.
     public func clientCertificate(_ clientCertificate: URL, _ clientKey: URL) -> NatsClientOptions {
         self.clientCertificate = clientCertificate
         self.clientKey = clientKey
         return self
     }
 
+    /// Indicates whether the client will retain the order of URLs to connect to provided in ``NatsClientOptions/urls(_:)``
+    /// If not set, the client will randomize the server pool.
     public func retainServersOrder() -> NatsClientOptions {
         self.noRandomize = true
         return self
     }
 
+    /// By default, ``NatsClient/connect()`` will return an error if
+    /// the connection to the server cannot be established.
+    ///
+    /// Setting `retryOnfailedConnect()` makes the client
+    /// establish the connection in the background even if the initial connect fails.
     public func retryOnfailedConnect() -> NatsClientOptions {
         self.initialReconnect = true
         return self

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -154,7 +154,8 @@ class ConnectionHandler: ChannelInboundHandler {
                         try await self.write(operation: .pong)
                     } catch {
                         logger.error("error sending pong: \(error)")
-                        self.fire(.error(NatsClientError("error sending pong: \(error)")))
+                        self.fire(
+                            .error(NatsError.ClientError.other("error sending pong: \(error)")))
                     }
                 }
             case .pong:
@@ -225,7 +226,7 @@ class ConnectionHandler: ChannelInboundHandler {
         for s in servers {
             if let maxReconnects {
                 if reconnectAttempts >= maxReconnects {
-                    throw NatsClientError("could not reconnect; maxReconnects exceeded")
+                    throw NatsError.ClientError.maxReconnects
                 }
 
             }
@@ -236,10 +237,15 @@ class ConnectionHandler: ChannelInboundHandler {
 
             do {
                 try await connectToServer(s: s)
-            } catch let error as NatsConfigError {
-                throw error
+            } catch let error as NatsError.ConnectError {
+                if case .invalidConfig(_) = error {
+                    throw error
+                }
+                logger.debug("error connecting to server: \(error)")
+                lastErr = error
+                continue
             } catch {
-                logger.error("error connecting to server: \(error)")
+                logger.debug("error connecting to server: \(error)")
                 lastErr = error
                 continue
             }
@@ -248,11 +254,39 @@ class ConnectionHandler: ChannelInboundHandler {
         }
         if let lastErr {
             self.state = .disconnected
-            throw lastErr
+            switch lastErr {
+            case let error as ChannelError:
+                self.serverInfoContinuation = nil
+                var err: NatsError.ConnectError
+                switch error.self {
+                case .connectTimeout(_):
+                    err = .timeout
+                default:
+                    err = .io(error)
+
+                }
+                throw err
+            case let error as NIOConnectionError:
+                if let dnsAAAAError = error.dnsAAAAError {
+                    throw NatsError.ConnectError.dns(dnsAAAAError)
+                } else if let dnsAError = error.dnsAError {
+                    throw NatsError.ConnectError.dns(dnsAError)
+                } else {
+                    throw NatsError.ConnectError.io(error)
+                }
+            case let err as NIOSSLError:
+                throw NatsError.ConnectError.tlsFailure(err)
+            case let err as BoringSSLError:
+                throw NatsError.ConnectError.tlsFailure(err)
+            case let err as NatsError.ServerError:
+                throw err
+            default:
+                throw NatsError.ConnectError.io(lastErr)
+            }
         }
         self.reconnectAttempts = 0
         guard let channel = self.channel else {
-            throw NatsClientError("internal error: empty channel")
+            throw NatsError.ClientError.internalError("empty channel")
         }
         // Schedule the task to send a PING periodically
         let pingInterval = TimeAmount.nanoseconds(Int64(self.pingInterval * 1_000_000_000))
@@ -267,21 +301,23 @@ class ConnectionHandler: ChannelInboundHandler {
 
     private func connectToServer(s: URL) async throws {
         var infoTask: Task<(), Never>? = nil
+        // this continuation can throw NatsError.ServerError if server responds with
+        // -ERR to client connect (e.g. auth error)
         let info = try await withCheckedThrowingContinuation { continuation in
             self.serverInfoContinuation = continuation
             infoTask = Task {
                 do {
-                    let (bootstrap, upgradePromise) = try self.bootstrapConnection(to: s)
+                    let (bootstrap, upgradePromise) = self.bootstrapConnection(to: s)
                     guard let host = s.host, let port = s.port else {
                         upgradePromise.succeed()  // avoid promise leaks
-                        throw NatsConfigError("no url")
+                        throw NatsError.ConnectError.invalidConfig("no url")
                     }
                     let connect = bootstrap.connect(host: host, port: port)
                     connect.cascadeFailure(to: upgradePromise)
                     self.channel = try await connect.get()
                     guard let channel = self.channel else {
                         upgradePromise.succeed()  // avoid promise leaks
-                        throw NatsClientError("internal error: empty channel")
+                        throw NatsError.ClientError.internalError("empty channel")
                     }
 
                     try await upgradePromise.futureResult.get()
@@ -340,18 +376,20 @@ class ConnectionHandler: ChannelInboundHandler {
             authToken: self.auth?.token ?? "", headers: true, noResponders: true)
 
         if self.auth?.nkey != nil && self.auth?.nkeyPath != nil {
-            throw NatsConfigError("cannot use both nkey and nkeyPath")
+            throw NatsError.ConnectError.invalidConfig("cannot use both nkey and nkeyPath")
         }
         if let auth = self.auth, let credentialsPath = auth.credentialsPath {
             let credentials = try await URLSession.shared.data(from: credentialsPath).0
             guard let jwt = JwtUtils.parseDecoratedJWT(contents: credentials) else {
-                throw NatsConfigError("failed to extract JWT from credentials file")
+                throw NatsError.ConnectError.invalidConfig(
+                    "failed to extract JWT from credentials file")
             }
             guard let nkey = JwtUtils.parseDecoratedNKey(contents: credentials) else {
-                throw NatsConfigError("failed to extract NKEY from credentials file")
+                throw NatsError.ConnectError.invalidConfig(
+                    "failed to extract NKEY from credentials file")
             }
             guard let nonce = self.serverInfo?.nonce else {
-                throw NatsConfigError("missing nonce")
+                throw NatsError.ConnectError.invalidConfig("missing nonce")
             }
             let keypair = try KeyPair(seed: String(data: nkey, encoding: .utf8)!)
             let nonceData = nonce.data(using: .utf8)!
@@ -364,14 +402,14 @@ class ConnectionHandler: ChannelInboundHandler {
             let nkeyData = try await URLSession.shared.data(from: nkey).0
 
             guard let nkeyContent = String(data: nkeyData, encoding: .utf8) else {
-                throw NatsConfigError("failed to read NKEY file")
+                throw NatsError.ConnectError.invalidConfig("failed to read NKEY file")
             }
             let keypair = try KeyPair(
                 seed: nkeyContent.trimmingCharacters(in: .whitespacesAndNewlines)
             )
 
             guard let nonce = self.serverInfo?.nonce else {
-                throw NatsConfigError("missing nonce")
+                throw NatsError.ConnectError.invalidConfig("missing nonce")
             }
             let sig = try keypair.sign(input: nonce.data(using: .utf8)!)
             let base64sig = sig.base64EncodedURLSafeNotPadded()
@@ -381,7 +419,7 @@ class ConnectionHandler: ChannelInboundHandler {
         if let nkey = self.auth?.nkey {
             let keypair = try KeyPair(seed: nkey)
             guard let nonce = self.serverInfo?.nonce else {
-                throw NatsConfigError("missing nonce")
+                throw NatsError.ConnectError.invalidConfig("missing nonce")
             }
             let nonceData = nonce.data(using: .utf8)!
             let sig = try keypair.sign(input: nonceData)
@@ -390,6 +428,8 @@ class ConnectionHandler: ChannelInboundHandler {
             initialConnect.nkey = keypair.publicKeyEncoded
         }
         let connect = initialConnect
+        // this continuation can throw NatsError.ServerError if server responds with
+        // -ERR to client connect (e.g. auth error)
         try await withCheckedThrowingContinuation { continuation in
             self.connectionEstablishedContinuation = continuation
             Task.detached {
@@ -406,7 +446,7 @@ class ConnectionHandler: ChannelInboundHandler {
 
     private func bootstrapConnection(
         to server: URL
-    ) throws -> (ClientBootstrap, EventLoopPromise<Void>) {
+    ) -> (ClientBootstrap, EventLoopPromise<Void>) {
         let upgradePromise: EventLoopPromise<Void> = self.group.any().makePromise(of: Void.self)
         let bootstrap = ClientBootstrap(group: self.group)
             .channelOption(
@@ -436,7 +476,8 @@ class ConnectionHandler: ChannelInboundHandler {
                         }
                         return channel.eventLoop.makeSucceededFuture(())
                     } catch {
-                        return channel.eventLoop.makeFailedFuture(error)
+                        let tlsError = NatsError.ConnectError.tlsFailure(error)
+                        return channel.eventLoop.makeFailedFuture(tlsError)
                     }
                 } else {
                     if server.scheme == "ws" || server.scheme == "wss" {
@@ -487,8 +528,9 @@ class ConnectionHandler: ChannelInboundHandler {
                                 // due to the promise originating on the event loop of the channel.
                                 try channel.pipeline.syncOperations.addHandler(sslHandler)
                             } catch {
-                                upgradePromise.fail(error)
-                                return channel.eventLoop.makeFailedFuture(error)
+                                let tlsError = NatsError.ConnectError.tlsFailure(error)
+                                upgradePromise.fail(tlsError)
+                                return channel.eventLoop.makeFailedFuture(tlsError)
                             }
                         }
 
@@ -542,7 +584,7 @@ class ConnectionHandler: ChannelInboundHandler {
         await self.reconnectTask?.value
 
         guard let eventLoop = self.channel?.eventLoop else {
-            throw NatsClientError("internal error: channel should not be nil")
+            throw NatsError.ClientError.internalError("channel should not be nil")
         }
         let promise = eventLoop.makePromise(of: Void.self)
 
@@ -566,7 +608,7 @@ class ConnectionHandler: ChannelInboundHandler {
         _ = await self.reconnectTask?.value
 
         guard let eventLoop = self.channel?.eventLoop else {
-            throw NatsClientError("internal error: channel should not be nil")
+            throw NatsError.ClientError.internalError("channel should not be nil")
         }
         let promise = eventLoop.makePromise(of: Void.self)
 
@@ -587,11 +629,11 @@ class ConnectionHandler: ChannelInboundHandler {
 
     func resume() async throws {
         guard let eventLoop = self.channel?.eventLoop else {
-            throw NatsClientError("internal error: channel should not be nil")
+            throw NatsError.ClientError.internalError("channel should not be nil")
         }
         try await eventLoop.submit {
             guard self.state == .suspended else {
-                throw NatsClientError(
+                throw NatsError.ClientError.other(
                     "unable to resume connection - connection is not in suspended state")
             }
             self.handleReconnect()
@@ -638,7 +680,7 @@ class ConnectionHandler: ChannelInboundHandler {
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         logger.debug("Encountered error on the channel: \(error)")
         context.close(promise: nil)
-        if let natsErr = error as? NatsError {
+        if let natsErr = error as? NatsErrorProtocol {
             self.fire(.error(natsErr))
         } else {
             logger.error("unexpected error: \(error)")
@@ -740,7 +782,7 @@ class ConnectionHandler: ChannelInboundHandler {
 
     func write(operation: ClientOp) async throws {
         guard let buffer = self.batchBuffer else {
-            throw NatsClientError("not connected")
+            throw NatsError.ClientError.other("not connected")
         }
         try await buffer.writeMessage(operation)
     }
@@ -835,7 +877,7 @@ public enum NatsEvent {
     case suspended
     case closed
     case lameDuckMode
-    case error(NatsError)
+    case error(NatsErrorProtocol)
 
     public func kind() -> NatsEventKind {
         switch self {

--- a/Sources/Nats/NatsError.swift
+++ b/Sources/Nats/NatsError.swift
@@ -64,7 +64,7 @@ public enum NatsError {
         case maxReconnects
         case connectionClosed
         case io(Error)
-        case other(String)
+        case invalidConnection(String)
 
         public var description: String {
             switch self {
@@ -76,7 +76,7 @@ public enum NatsError {
                 return "nats: connection is closed"
             case .io(let error):
                 return "nats: IO error: \(error)"
-            case .other(let error):
+            case .invalidConnection(let error):
                 return "nats: \(error)"
             }
         }

--- a/Sources/Nats/NatsError.swift
+++ b/Sources/Nats/NatsError.swift
@@ -11,51 +11,117 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public protocol NatsError: Error {
-    var description: String { get }
-}
+import Foundation
 
-public struct NatsServerError: NatsError {
-    public var description: String
-    var normalizedError: String {
-        return description.trimWhitespacesAndApostrophes().lowercased()
+public protocol NatsErrorProtocol: Error, CustomStringConvertible {}
+
+public enum NatsError {
+    public enum ServerError: NatsErrorProtocol {
+        case autorization(String)
+        case other(String)
+
+        public var description: String {
+            switch self {
+            case .autorization(let type):
+                return "nats: authorization error: \(type)"
+            case .other(let error):
+                return "nats: \(error)"
+            }
+        }
+        var normalizedError: String {
+            return description.trimWhitespacesAndApostrophes().lowercased()
+        }
+        init(_ error: String) {
+            let normalizedError = error.trimWhitespacesAndApostrophes().lowercased()
+            if normalizedError.contains("authorization violation")
+                || normalizedError.contains("user authentication expired")
+                || normalizedError.contains("user authentication revoked")
+                || normalizedError.contains("account authentication expired")
+            {
+                self = .autorization(normalizedError)
+            } else {
+                self = .other(normalizedError)
+            }
+        }
     }
-    init(_ description: String) {
-        self.description = description
+
+    public enum ProtocolError: NatsErrorProtocol {
+        case invalidOperation(String)
+        case parserFailure(String)
+
+        public var description: String {
+            switch self {
+            case .invalidOperation(let op):
+                return "nats: unknown server operation: \(op)"
+            case .parserFailure(let cause):
+                return "nats: parser failure: \(cause)"
+            }
+        }
     }
-}
 
-public struct NatsParserError: NatsError {
-    public var description: String
-    init(_ description: String) {
-        self.description = description
+    public enum ClientError: NatsErrorProtocol {
+        case internalError(String)
+        case maxReconnects
+        case other(String)
+
+        public var description: String {
+            switch self {
+            case .internalError(let error):
+                return "nats: internal error: \(error)"
+            case .maxReconnects:
+                return "nats: max reconnects exceeded"
+            case .other(let error):
+                return "nats: \(error)"
+            }
+        }
     }
-}
 
-public struct NatsClientError: NatsError {
-    public var description: String
-    init(_ description: String) {
-        self.description = description
+    public enum ConnectError: NatsErrorProtocol {
+        case invalidConfig(String)
+        case tlsFailure(Error)
+        case timeout
+        case dns(Error)
+        case io(Error)
+
+        public var description: String {
+            switch self {
+            case .invalidConfig(let error):
+                return "nats: invalid client configuration: \(error)"
+            case .tlsFailure(let error):
+                return "nats: TLS error: \(error)"
+            case .timeout:
+                return "nats: timed out waiting for connection"
+            case .dns(let error):
+                return "nats: DNS lookup error: \(error)"
+            case .io(let error):
+                return "nats: error establishing connection: \(error)"
+            }
+        }
     }
-}
 
-public struct NatsConfigError: NatsError {
-    public var description: String
-    init(_ description: String) {
-        self.description = description
+    public enum RequestError: NatsErrorProtocol {
+        case noResponders
+        case timeout
+
+        public var description: String {
+            switch self {
+            case .noResponders:
+                return "nats: no responders available for request"
+            case .timeout:
+                return "nats: request timed out"
+            }
+        }
     }
-}
 
-public enum NatsRequestError: NatsError {
-    case noResponders
-    case timeout
+    public enum ParseHeaderError: NatsErrorProtocol {
+        case invalidCharacter
 
-    public var description: String {
-        switch self {
-        case .noResponders:
-            return "no responders available for request"
-        case .timeout:
-            return "request timed out"
+        public var description: String {
+            switch self {
+            case .invalidCharacter:
+                return
+                    "Invalid header name (name cannot contain non-ascii alphanumeric characters other than '-')"
+            }
         }
     }
 }

--- a/Sources/Nats/NatsError.swift
+++ b/Sources/Nats/NatsError.swift
@@ -62,6 +62,8 @@ public enum NatsError {
     public enum ClientError: NatsErrorProtocol {
         case internalError(String)
         case maxReconnects
+        case connectionClosed
+        case io(Error)
         case other(String)
 
         public var description: String {
@@ -70,6 +72,10 @@ public enum NatsError {
                 return "nats: internal error: \(error)"
             case .maxReconnects:
                 return "nats: max reconnects exceeded"
+            case .connectionClosed:
+                return "nats: connection is closed"
+            case .io(let error):
+                return "nats: IO error: \(error)"
             case .other(let error):
                 return "nats: \(error)"
             }
@@ -113,6 +119,17 @@ public enum NatsError {
         }
     }
 
+    public enum SubscriptionError: NatsErrorProtocol {
+        case subscriptionClosed
+
+        public var description: String {
+            switch self {
+            case .subscriptionClosed:
+                return "nats: subscription closed"
+            }
+        }
+    }
+
     public enum ParseHeaderError: NatsErrorProtocol {
         case invalidCharacter
 
@@ -120,7 +137,7 @@ public enum NatsError {
             switch self {
             case .invalidCharacter:
                 return
-                    "Invalid header name (name cannot contain non-ascii alphanumeric characters other than '-')"
+                    "nats: invalid header name (name cannot contain non-ascii alphanumeric characters other than '-')"
             }
         }
     }

--- a/Sources/Nats/NatsSubscription.swift
+++ b/Sources/Nats/NatsSubscription.swift
@@ -110,8 +110,22 @@ public class NatsSubscription: AsyncSequence {
         return msg
     }
 
+    /// Unsubscribes from subscription.
+    ///
+    /// - Parameter after: if set, unsubscribe will be performed after reaching given number of messages.
+    ///   If it already reached or surpassed the passed value, it will immediately stop.
+    ///
+    /// - Throws:
+    ///   - ``NatsError/ClientError/connectionClosed`` if the conneciton is closed.
+    ///   - ``NatsError/SubscriptionError/subscriptionClosed`` if the subscription is already closed
     public func unsubscribe(after: UInt64? = nil) async throws {
         logger.info("unsubscribe from subject \(subject)")
+        if case .closed = self.conn.state {
+            throw NatsError.ClientError.connectionClosed
+        }
+        if self.closed {
+            throw NatsError.SubscriptionError.subscriptionClosed
+        }
         return try await self.conn.unsubscribe(sub: self, max: after)
     }
 }


### PR DESCRIPTION
This introduces several changes to how errors in core NATS are handled:
- errors are namespaced under `NatsError` enum
- Individual error types are enums containing specific error conditions
- There are more "generic" errors, e.g. `NatsError.ServerError` and more specific errors which do not fall under other   category but are method-specific (e.g. `NatsError.ConnectError`)

Additionally, this PR includes adding documentation to most of public methods in core NATS and fixes a mutex deadlock condition.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)