### PR TITLE
Add cancellation to async tasks

### DIFF
--- a/Sources/Nats/NatsError.swift
+++ b/Sources/Nats/NatsError.swift
@@ -147,6 +147,7 @@ public enum NatsError {
         case connectionClosed
         case io(Error)
         case invalidConnection(String)
+        case cancelled
 
         public var description: String {
             switch self {
@@ -160,6 +161,8 @@ public enum NatsError {
                 return "nats: IO error: \(error)"
             case .invalidConnection(let error):
                 return "nats: \(error)"
+            case .cancelled:
+                return "nats: operation cancelled"
             }
         }
     }


### PR DESCRIPTION
- added cancellation handling for info and connection established continuations
- cleaned up `handleReconnect()` cancellation
- fixed a bug where `maxReconnects(0)` causes the client to abandon the initial connect

Addresses #84 #86 

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)