### PR TITLE
Fix continuation leak crashes and TLS error propagation

### DIFF
--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -139,24 +139,31 @@ class ConnectionHandler: ChannelInboundHandler {
             parseRemainder.withLockedValue { $0 = remainder }
         }
         for op in parseResult.ops {
-            let continuationToResume = serverInfoContinuation.withLockedValue { cont in
-                let toResume = cont
-                cont = nil
-                return toResume
-            }
-
-            if let continuation = continuationToResume {
-                logger.debug("server info")
-                switch op {
-                case .error(let err):
+            // Only resume the server info continuation when we actually receive
+            // an INFO or -ERR op. Do NOT clear it for unrelated ops.
+            switch op {
+            case .error(let err):
+                if let continuation = serverInfoContinuation.withLockedValue({ cont in
+                    let toResume = cont
+                    cont = nil
+                    return toResume
+                }) {
+                    logger.debug("server info error")
                     continuation.resume(throwing: err)
-                case .info(let info):
-                    continuation.resume(returning: info)
-                default:
-                    // ignore until we get either error or server info
                     continue
                 }
-                continue
+            case .info(let info):
+                if let continuation = serverInfoContinuation.withLockedValue({ cont in
+                    let toResume = cont
+                    cont = nil
+                    return toResume
+                }) {
+                    logger.debug("server info")
+                    continuation.resume(returning: info)
+                    continue
+                }
+            default:
+                break
             }
 
             let connEstablishedCont = connectionEstablishedContinuation.withLockedValue { cont in
@@ -273,6 +280,7 @@ class ConnectionHandler: ChannelInboundHandler {
     }
 
     func connect() async throws {
+        self.setState(.connecting)
         var servers = self.urls
         if !self.retainServersOrder {
             servers = self.urls.shuffled()
@@ -805,6 +813,24 @@ class ConnectionHandler: ChannelInboundHandler {
 
     func channelInactive(context: ChannelHandlerContext) {
         logger.debug("TCP channel inactive")
+
+        // If we lost the channel before we delivered server INFO or connection
+        // establishment, make sure to fail any pending continuations to avoid leaks.
+        if let continuation = serverInfoContinuation.withLockedValue({ cont in
+            let toResume = cont
+            cont = nil
+            return toResume
+        }) {
+            continuation.resume(throwing: NatsError.ClientError.connectionClosed)
+        }
+
+        if let continuation = connectionEstablishedContinuation.withLockedValue({ cont in
+            let toResume = cont
+            cont = nil
+            return toResume
+        }) {
+            continuation.resume(throwing: NatsError.ClientError.connectionClosed)
+        }
 
         let shouldHandleDisconnect = state.withLockedValue { $0 == .connected }
         if shouldHandleDisconnect {

--- a/Tests/JetStreamTests/Integration/ConsumerTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerTests.swift
@@ -41,7 +41,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -77,7 +77,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -120,7 +120,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -156,7 +156,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -183,7 +183,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -223,7 +223,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -272,7 +272,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -318,7 +318,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -373,7 +373,7 @@ class ConsumerTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()

--- a/Tests/JetStreamTests/Integration/JetStreamTests.swift
+++ b/Tests/JetStreamTests/Integration/JetStreamTests.swift
@@ -53,7 +53,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -83,7 +83,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "prefix", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let clientA = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
@@ -108,7 +108,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "domain", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
@@ -121,7 +121,7 @@ class JetStreamTests: XCTestCase {
 
     func testJetStreamNotEnabled() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -139,7 +139,7 @@ class JetStreamTests: XCTestCase {
 
     func testJetStreamNotEnabledForAccount() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -159,7 +159,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -251,7 +251,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -282,7 +282,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -319,7 +319,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -386,7 +386,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -436,7 +436,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -483,7 +483,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -536,7 +536,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -580,7 +580,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -627,7 +627,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -673,7 +673,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -763,7 +763,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -853,7 +853,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -884,7 +884,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -902,7 +902,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -944,7 +944,7 @@ class JetStreamTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()

--- a/Tests/JetStreamTests/Integration/RequestTests.swift
+++ b/Tests/JetStreamTests/Integration/RequestTests.swift
@@ -31,7 +31,7 @@ class RequestTests: XCTestCase {
         let bundle = Bundle.module
         natsServer.start(
             cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -67,7 +67,7 @@ class CoreNatsTests: XCTestCase {
 
     func testRtt() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -81,7 +81,7 @@ class CoreNatsTests: XCTestCase {
 
     func testPublish() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -103,7 +103,7 @@ class CoreNatsTests: XCTestCase {
 
     func testSuspendAndResume() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -148,7 +148,7 @@ class CoreNatsTests: XCTestCase {
 
     func testForceReconnect() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -192,7 +192,7 @@ class CoreNatsTests: XCTestCase {
 
     func testConnectMultipleURLsOneIsValid() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .urls([
                 URL(string: natsServer.clientURL)!, URL(string: "nats://localhost:4344")!,
@@ -219,7 +219,7 @@ class CoreNatsTests: XCTestCase {
         natsServer.start()
         let natsServer2 = NatsServer()
         natsServer2.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         for _ in 0..<10 {
             let client = NatsClientOptions()
                 .urls([URL(string: natsServer2.clientURL)!, URL(string: natsServer.clientURL)!])
@@ -232,7 +232,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testConnectDNSError() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .urls([URL(string: "nats://invalid:1234")!])
             .build()
@@ -247,7 +247,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testConnectNIOError() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .urls([URL(string: "nats://localhost:4321")!])
             .build()
@@ -284,7 +284,7 @@ class CoreNatsTests: XCTestCase {
 
     func testPublishWithReply() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -306,7 +306,7 @@ class CoreNatsTests: XCTestCase {
 
     func testSubscribe() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
         let sub = try await client.subscribe(subject: "test")
@@ -318,7 +318,7 @@ class CoreNatsTests: XCTestCase {
 
     func testQueueGroupSubscribe() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
 
@@ -364,7 +364,7 @@ class CoreNatsTests: XCTestCase {
 
     func testUnsubscribe() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
         let sub = try await client.subscribe(subject: "test")
@@ -389,7 +389,7 @@ class CoreNatsTests: XCTestCase {
 
     func testUnsubscribeAfter() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
         let sub = try await client.subscribe(subject: "test")
@@ -408,7 +408,7 @@ class CoreNatsTests: XCTestCase {
 
     func testConnect() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -419,7 +419,7 @@ class CoreNatsTests: XCTestCase {
     func testReconnect() async throws {
         natsServer.start()
         let port = natsServer.port!
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
@@ -480,7 +480,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testUsernameAndPassword() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         natsServer.start(cfg: bundle.url(forResource: "creds", withExtension: "conf")!.relativePath)
 
@@ -515,7 +515,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testTokenAuth() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         natsServer.start(cfg: bundle.url(forResource: "token", withExtension: "conf")!.relativePath)
 
@@ -549,7 +549,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testCredentialsAuth() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         natsServer.start(cfg: bundle.url(forResource: "jwt", withExtension: "conf")!.relativePath)
 
@@ -565,7 +565,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testNkeyAuth() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         natsServer.start(cfg: bundle.url(forResource: "nkey", withExtension: "conf")!.relativePath)
 
@@ -580,7 +580,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testNkeyAuthFile() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         natsServer.start(cfg: bundle.url(forResource: "nkey", withExtension: "conf")!.relativePath)
 
@@ -619,7 +619,7 @@ class CoreNatsTests: XCTestCase {
 
     func testMutualTls() async throws {
         let bundle = Bundle.module
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
         let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
@@ -650,7 +650,7 @@ class CoreNatsTests: XCTestCase {
 
     func testTlsFirst() async throws {
         let bundle = Bundle.module
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
         let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
@@ -682,7 +682,7 @@ class CoreNatsTests: XCTestCase {
 
     func testInvalidCertificate() async throws {
         let bundle = Bundle.module
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
         let rootCA = bundle.url(forResource: "rootCA", withExtension: "pem")!.relativePath
@@ -715,7 +715,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testWebsocket() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         natsServer.start(cfg: bundle.url(forResource: "ws", withExtension: "conf")!.relativePath)
 
@@ -732,7 +732,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testWebsocketTLS() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         let serverCert = bundle.url(forResource: "server-cert", withExtension: "pem")!.relativePath
         let serverKey = bundle.url(forResource: "server-key", withExtension: "pem")!.relativePath
@@ -767,7 +767,7 @@ class CoreNatsTests: XCTestCase {
 
     func testLameDuckMode() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
 
@@ -786,7 +786,7 @@ class CoreNatsTests: XCTestCase {
 
     func testRequest() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -806,7 +806,7 @@ class CoreNatsTests: XCTestCase {
 
     func testRequest_noResponders() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -823,7 +823,7 @@ class CoreNatsTests: XCTestCase {
 
     func testRequest_timeout() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()
@@ -849,7 +849,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testRequest_permissionDenied() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         let templateURL = bundle.url(forResource: "permissions", withExtension: "conf")!
         let cfgFile = try createConfigFileFromTemplate(
@@ -872,7 +872,7 @@ class CoreNatsTests: XCTestCase {
 
     func testPublishOnClosedConnection() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -894,7 +894,7 @@ class CoreNatsTests: XCTestCase {
 
     func testCloseClosedConnection() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -916,7 +916,7 @@ class CoreNatsTests: XCTestCase {
 
     func testSuspendClosedConnection() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -938,7 +938,7 @@ class CoreNatsTests: XCTestCase {
 
     func testReconnectOnClosedConnection() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)
             .build()
@@ -959,7 +959,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testSubscribeMissingPermissions() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         let cfgFile = try createConfigFileFromTemplate(
             templateURL: bundle.url(forResource: "permissions", withExtension: "conf")!,
@@ -1001,7 +1001,7 @@ class CoreNatsTests: XCTestCase {
     }
 
     func testSubscribePermissionsRevoked() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let bundle = Bundle.module
         let templateURL = bundle.url(forResource: "permissions", withExtension: "conf")!
         var cfgFile = try createConfigFileFromTemplate(

--- a/Tests/NatsTests/Integration/EventsTests.swift
+++ b/Tests/NatsTests/Integration/EventsTests.swift
@@ -34,7 +34,7 @@ class TestNatsEvents: XCTestCase {
 
     func testClientConnectedEvent() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
 
@@ -52,7 +52,7 @@ class TestNatsEvents: XCTestCase {
 
     func testClientClosedEvent() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
 
@@ -71,7 +71,7 @@ class TestNatsEvents: XCTestCase {
     func testClientReconnectEvent() async throws {
         natsServer.start()
         let port = natsServer.port!
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions()
             .url(URL(string: natsServer.clientURL)!)

--- a/Tests/NatsTests/Integration/MessageWithHeadersTests.swift
+++ b/Tests/NatsTests/Integration/MessageWithHeadersTests.swift
@@ -32,7 +32,7 @@ class TestMessageWithHeadersTests: XCTestCase {
 
     func testMessageWithHeaders() async throws {
         natsServer.start()
-        logger.logLevel = .debug
+        logger.logLevel = .critical
 
         let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
         try await client.connect()

--- a/Tests/NatsTests/Unit/JwtTests.swift
+++ b/Tests/NatsTests/Unit/JwtTests.swift
@@ -23,7 +23,7 @@ class JwtTests: XCTestCase {
     ]
 
     func testParseCredentialsFile() async throws {
-        logger.logLevel = .debug
+        logger.logLevel = .critical
         let currentFile = URL(fileURLWithPath: #file)
         let testDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
         let resourceURL = testDir.appendingPathComponent("Integration/Resources/TestUser.creds")

--- a/Tests/NatsTests/Unit/ParserTests.swift
+++ b/Tests/NatsTests/Unit/ParserTests.swift
@@ -192,7 +192,7 @@ class ParserTests: XCTestCase {
         ]
 
         for (tn, tc) in testCases.enumerated() {
-            logger.logLevel = .debug
+            logger.logLevel = .critical
             var ops = [ServerOp]()
             var prevRemainder: Data?
             for chunk in tc.givenChunks {


### PR DESCRIPTION
- Fix continuation leak crashes that caused "SWIFT TASK CONTINUATION MISUSE" errors
- Fix TLS error propagation race condition in connection handling  
- Ensure proper error reporting for SSL/TLS failures
- Change log level in tests to reduce noise

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)