### PR TITLE
Add noEcho() and connectionName() to NatsClientOptions

### DIFF
--- a/Sources/Nats/NatsClient/NatsClientOptions.swift
+++ b/Sources/Nats/NatsClient/NatsClientOptions.swift
@@ -22,6 +22,8 @@ public class NatsClientOptions {
     private var pingInterval: TimeInterval = 60.0
     private var reconnectWait: TimeInterval = 2.0
     private var maxReconnects: Int?
+    private var connectionName: String?
+    private var noEcho = false
     private var initialReconnect = false
     private var noRandomize = false
     private var auth: Auth? = nil
@@ -80,6 +82,20 @@ public class NatsClientOptions {
     /// Defaults to unlimited.
     public func maxReconnects(_ maxReconnects: Int) -> NatsClientOptions {
         self.maxReconnects = maxReconnects
+        return self
+    }
+
+    /// Connection name.
+    public func connectionName(_ connectionName: String) -> NatsClientOptions {
+        self.connectionName = connectionName
+        return self
+    }
+
+    /// NoEcho server option.
+    /// If set to `true`, the server (version 1.2.0+) will not send originating
+    /// messages from this connection to its own subscriptions.
+    public func noEcho(_ noEcho: Bool) -> NatsClientOptions {
+        self.noEcho = noEcho
         return self
     }
 
@@ -187,6 +203,8 @@ public class NatsClientOptions {
             urls: urls,
             reconnectWait: reconnectWait,
             maxReconnects: maxReconnects,
+            connectionName: connectionName,
+            noEcho: noEcho,
             retainServersOrder: noRandomize,
             pingInterval: pingInterval,
             auth: auth,

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -51,6 +51,8 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
     // nanoseconds representation of TimeInterval
     private let reconnectWait: UInt64
     private let maxReconnects: Int?
+    private let connectionName: String?
+    private let noEcho: Bool
     private let retainServersOrder: Bool
     private let pingInterval: TimeInterval
     private let requireTls: Bool
@@ -117,6 +119,8 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
 
     init(
         urls: [URL], reconnectWait: TimeInterval, maxReconnects: Int?,
+        connectionName: String?,
+        noEcho: Bool,
         retainServersOrder: Bool,
         pingInterval: TimeInterval, auth: Auth?, requireTls: Bool, tlsFirst: Bool,
         clientCertificate: URL?, clientKey: URL?,
@@ -127,6 +131,8 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
         self._inputBuffer = NIOLockedValueBox(allocator.buffer(capacity: 1024))
         self.reconnectWait = UInt64(reconnectWait * 1_000_000_000)
         self.maxReconnects = maxReconnects
+        self.connectionName = connectionName
+        self.noEcho = noEcho
         self.retainServersOrder = retainServersOrder
         self.auth = auth
         self.pingInterval = pingInterval
@@ -531,7 +537,8 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
 
     private func sendClientConnectInit() async throws {
         var initialConnect = ConnectInfo(
-            verbose: false, pedantic: false, userJwt: nil, nkey: "", name: "", echo: true,
+            verbose: false, pedantic: false, userJwt: nil, nkey: "",
+            name: self.connectionName ?? "", echo: !self.noEcho,
             lang: self.lang, version: self.version, natsProtocol: .dynamic, tlsRequired: false,
             user: self.auth?.user ?? "", pass: self.auth?.password ?? "",
             authToken: self.auth?.token ?? "", headers: true, noResponders: true)


### PR DESCRIPTION
This PR exposes two additional connection options on par with the other official Nats clients.
The change is fully backwards compatible.

Eg.:
```swift
let nats = NatsClientOptions()
    .url(URL(string: "nats://localhost:4222")!)
    .connectionName("MyConnection")
    .noEcho(true)
    .build()
```