### PR TITLE
Add Consumer.consume() 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,6 +63,7 @@ let package = Package(
         .executableTarget(name: "Benchmark", dependencies: ["Nats"]),
         .executableTarget(name: "BenchmarkPubSub", dependencies: ["Nats"]),
         .executableTarget(name: "BenchmarkSub", dependencies: ["Nats"]),
+        .executableTarget(name: "BenchmarkConsume", dependencies: ["Nats", "JetStream"]),
         .executableTarget(name: "Example", dependencies: ["Nats"]),
     ]
 )

--- a/Sources/BenchmarkConsume/main.swift
+++ b/Sources/BenchmarkConsume/main.swift
@@ -1,0 +1,206 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import JetStream
+import Nats
+
+// Benchmark: consume() vs fetch() throughput
+//
+// Runs fetch first to eliminate cold-start bias, then alternates
+// between consume and fetch across multiple passes.
+//
+// Usage:
+//   swift run -c release BenchmarkConsume [numMessages]
+
+let numMsgs =
+    CommandLine.arguments.count > 1
+    ? Int(CommandLine.arguments[1]) ?? 100_000
+    : 100_000
+
+let client = NatsClientOptions()
+    .url(URL(string: "nats://localhost:4222")!)
+    .build()
+
+print("Connecting...")
+try await client.connect()
+print("Connected!")
+
+let ctx = JetStreamContext(client: client)
+
+// Setup: create stream
+do {
+    _ = try await ctx.getStream(name: "BENCH")
+    _ = try await ctx.deleteStream(name: "BENCH")
+} catch {}
+let stream = try await ctx.createStream(
+    cfg: StreamConfig(name: "BENCH", subjects: ["bench.*"]))
+
+let payload = String(repeating: "x", count: 128).data(using: .utf8)!
+
+// Helper to publish N messages
+func publishMessages(_ n: Int) async throws {
+    for i in 0..<n {
+        _ = try await ctx.publish("bench.data", message: payload)
+        if (i + 1) % 50_000 == 0 {
+            print("  published \(i + 1)...")
+        }
+    }
+}
+
+var consumerSeq = 0
+func nextConsumerName() -> String {
+    consumerSeq += 1
+    return "bench_\(consumerSeq)"
+}
+
+// Benchmark helpers
+func benchmarkConsume(ack: Bool) async throws -> Double {
+    let name = nextConsumerName()
+    let cfg =
+        ack
+        ? ConsumerConfig(name: name)
+        : ConsumerConfig(name: name, ackPolicy: .none)
+    let consumer = try await stream.createConsumer(cfg: cfg)
+    try await publishMessages(numMsgs)
+
+    let msgs = try await consumer.consume(
+        config: ConsumeConfig(maxMessages: 500, expires: 30))
+    var count = 0
+    let start = DispatchTime.now()
+    for try await msg in msgs {
+        if ack { try await msg.ack() }
+        count += 1
+        if count >= numMsgs { msgs.stop() }
+    }
+    let elapsed =
+        Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+    return Double(count) / elapsed
+}
+
+func benchmarkFetch(ack: Bool) async throws -> Double {
+    let name = nextConsumerName()
+    let cfg =
+        ack
+        ? ConsumerConfig(name: name)
+        : ConsumerConfig(name: name, ackPolicy: .none)
+    let consumer = try await stream.createConsumer(cfg: cfg)
+    try await publishMessages(numMsgs)
+
+    var count = 0
+    let start = DispatchTime.now()
+    while count < numMsgs {
+        let batch = try await consumer.fetch(batch: 500, expires: 5)
+        for try await msg in batch {
+            if ack { try await msg.ack() }
+            count += 1
+        }
+    }
+    let elapsed =
+        Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+    return Double(count) / elapsed
+}
+
+func fmt(_ rate: Double) -> String { String(format: "%7d", Int(rate)) }
+func fmtRatio(_ a: Double, _ b: Double) -> String { String(format: "%.2f", a / b) }
+
+// ═══════════════════════════════════════════════════════
+//  Warmup
+// ═══════════════════════════════════════════════════════
+print("\n--- Warmup (1000 msgs, results discarded) ---")
+let warmupCfg = ConsumerConfig(name: "warmup", ackPolicy: .none)
+let warmupCons = try await stream.createConsumer(cfg: warmupCfg)
+for _ in 0..<1000 {
+    _ = try await ctx.publish("bench.data", message: payload)
+}
+let warmupMsgs = try await warmupCons.consume(
+    config: ConsumeConfig(maxMessages: 500, expires: 5))
+var warmupCount = 0
+for try await _ in warmupMsgs {
+    warmupCount += 1
+    if warmupCount >= 1000 { warmupMsgs.stop() }
+}
+print("Warmup done (\(warmupCount) msgs)")
+
+// ═══════════════════════════════════════════════════════
+//  Pass 1: fetch first, then consume (with ack)
+// ═══════════════════════════════════════════════════════
+print("\n=== Pass 1: with ack (fetch first) ===")
+print("  fetch...")
+let fetchAck1 = try await benchmarkFetch(ack: true)
+print("  fetch()+ack:    \(fmt(fetchAck1)) msgs/s")
+print("  consume...")
+let consumeAck1 = try await benchmarkConsume(ack: true)
+print("  consume()+ack:  \(fmt(consumeAck1)) msgs/s")
+
+// ═══════════════════════════════════════════════════════
+//  Pass 2: consume first, then fetch (with ack)
+// ═══════════════════════════════════════════════════════
+print("\n=== Pass 2: with ack (consume first) ===")
+print("  consume...")
+let consumeAck2 = try await benchmarkConsume(ack: true)
+print("  consume()+ack:  \(fmt(consumeAck2)) msgs/s")
+print("  fetch...")
+let fetchAck2 = try await benchmarkFetch(ack: true)
+print("  fetch()+ack:    \(fmt(fetchAck2)) msgs/s")
+
+// ═══════════════════════════════════════════════════════
+//  Pass 3: no ack (fetch first)
+// ═══════════════════════════════════════════════════════
+print("\n=== Pass 3: no ack (fetch first) ===")
+print("  fetch...")
+let fetchNoAck1 = try await benchmarkFetch(ack: false)
+print("  fetch() no ack:    \(fmt(fetchNoAck1)) msgs/s")
+print("  consume...")
+let consumeNoAck1 = try await benchmarkConsume(ack: false)
+print("  consume() no ack:  \(fmt(consumeNoAck1)) msgs/s")
+
+// ═══════════════════════════════════════════════════════
+//  Pass 4: no ack (consume first)
+// ═══════════════════════════════════════════════════════
+print("\n=== Pass 4: no ack (consume first) ===")
+print("  consume...")
+let consumeNoAck2 = try await benchmarkConsume(ack: false)
+print("  consume() no ack:  \(fmt(consumeNoAck2)) msgs/s")
+print("  fetch...")
+let fetchNoAck2 = try await benchmarkFetch(ack: false)
+print("  fetch() no ack:    \(fmt(fetchNoAck2)) msgs/s")
+
+// ═══════════════════════════════════════════════════════
+//  Summary
+// ═══════════════════════════════════════════════════════
+let avgConsumeAck = (consumeAck1 + consumeAck2) / 2
+let avgFetchAck = (fetchAck1 + fetchAck2) / 2
+let avgConsumeNoAck = (consumeNoAck1 + consumeNoAck2) / 2
+let avgFetchNoAck = (fetchNoAck1 + fetchNoAck2) / 2
+
+print("\n══════════════════════════════════════════════")
+print("  \(numMsgs) messages, 128-byte payload")
+print("══════════════════════════════════════════════")
+print("              With ack          No ack")
+print("  consume: \(fmt(avgConsumeAck))  avg    \(fmt(avgConsumeNoAck))  avg")
+print("  fetch:   \(fmt(avgFetchAck))  avg    \(fmt(avgFetchNoAck))  avg")
+print(
+    "  ratio:    \(fmtRatio(avgConsumeAck, avgFetchAck))x          \(fmtRatio(avgConsumeNoAck, avgFetchNoAck))x"
+)
+print("")
+print("  Per-pass detail:")
+print("    ack pass1 (fetch 1st): consume \(fmt(consumeAck1))  fetch \(fmt(fetchAck1))")
+print("    ack pass2 (cons  1st): consume \(fmt(consumeAck2))  fetch \(fmt(fetchAck2))")
+print("    noack p3  (fetch 1st): consume \(fmt(consumeNoAck1))  fetch \(fmt(fetchNoAck1))")
+print("    noack p4  (cons  1st): consume \(fmt(consumeNoAck2))  fetch \(fmt(fetchNoAck2))")
+print("══════════════════════════════════════════════")
+
+// Cleanup
+try await ctx.deleteStream(name: "BENCH")
+try await client.close()

--- a/Sources/BenchmarkConsume/main.swift
+++ b/Sources/BenchmarkConsume/main.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Sources/JetStream/Consumer+Consume.swift
+++ b/Sources/JetStream/Consumer+Consume.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -268,32 +268,26 @@ public final class ConsumerMessages: AsyncSequence, Sendable {
     }
 
     private func preparePullRequest() throws -> Data? {
-        let (batch, maxBytesReq) = state.withLockedValue { state -> (Int, Int?) in
+        let result: (Int, Int?)? = state.withLockedValue { state -> (Int, Int?)? in
             let batch: Int
             let maxBytesReq: Int?
             if useBytes, let maxBytes = self.maxBytes {
                 batch = self.maxMessages - state.pendingMessages
                 let remainingBytes = maxBytes - state.pendingBytes
                 maxBytesReq = Swift.max(remainingBytes, 0)
+                guard batch > 0, let req = maxBytesReq, req > 0 else { return nil }
             } else {
                 batch = self.maxMessages - state.pendingMessages
                 maxBytesReq = nil
+                guard batch > 0 else { return nil }
             }
-            // Update pending counts
             state.pendingMessages += batch
             if let maxBytesReq {
                 state.pendingBytes += maxBytesReq
             }
             return (batch, maxBytesReq)
         }
-
-        // In bytes mode, also guard maxBytesReq > 0: NATS interprets
-        // max_bytes=0 as "no limit", which is the opposite of what we want.
-        if useBytes {
-            guard batch > 0, let req = maxBytesReq, req > 0 else { return nil }
-        } else {
-            guard batch > 0 else { return nil }
-        }
+        guard let (batch, maxBytesReq) = result else { return nil }
 
         let request = PullRequest(
             batch: batch,
@@ -560,26 +554,23 @@ public struct ConsumerIterator: AsyncIteratorProtocol, Sendable {
                     // this error indicates the server rejected the pull because
                     // batch size exceeds the consumer's MaxRequestBatch. Pull
                     // will be retried after the configured idle heartbeat
-                    // interval.
-                    messages.resetHeartbeatTime()
+                    // interval. Heartbeat is already reset by
+                    // adjustPendingAndResetHeartbeat above.
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning
                             .exceededMaxRequestBatch(description))
                     continue
                 } else if descLower.contains("exceeded maxrequestexpires") {
-                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning
                             .exceededMaxRequestExpires(description))
                     continue
                 } else if descLower.contains("exceeded maxrequestmaxbytes") {
-                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning
                             .exceededMaxRequestMaxBytes(description))
                     continue
                 } else if descLower.contains("exceeded maxwaiting") {
-                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning.exceededMaxWaiting(
                             description))

--- a/Sources/JetStream/Consumer+Consume.swift
+++ b/Sources/JetStream/Consumer+Consume.swift
@@ -1,0 +1,616 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import NIOConcurrencyHelpers
+import Nats
+
+/// Configuration for ``Consumer/consume(config:errorHandler:)``.
+public struct ConsumeConfig: Sendable {
+    /// Max messages buffered in client. Default: 500.
+    /// Mutually exclusive with ``maxBytes``.
+    public var maxMessages: Int?
+
+    /// Max bytes buffered in client. Default: not set (use ``maxMessages``).
+    /// Mutually exclusive with ``maxMessages``. When set, ``maxMessages`` is
+    /// internally overridden to 1,000,000 to bypass server batch_size == 0
+    /// behavior.
+    public var maxBytes: Int?
+
+    /// Timeout per pull request. Default: 30s. Minimum: 1s.
+    public var expires: TimeInterval
+
+    /// Idle heartbeat interval.
+    /// Default: ``expires`` / 2, capped at 30s, minimum 500ms.
+    public var idleHeartbeat: TimeInterval?
+
+    /// Message count threshold to trigger re-pull. Default: 50% of
+    /// ``maxMessages``.
+    public var thresholdMessages: Int?
+
+    /// Byte count threshold to trigger re-pull. Default: 50% of ``maxBytes``.
+    public var thresholdBytes: Int?
+
+    public init(
+        maxMessages: Int? = nil,
+        maxBytes: Int? = nil,
+        expires: TimeInterval = 30,
+        idleHeartbeat: TimeInterval? = nil,
+        thresholdMessages: Int? = nil,
+        thresholdBytes: Int? = nil
+    ) {
+        self.maxMessages = maxMessages
+        self.maxBytes = maxBytes
+        self.expires = expires
+        self.idleHeartbeat = idleHeartbeat
+        self.thresholdMessages = thresholdMessages
+        self.thresholdBytes = thresholdBytes
+    }
+}
+
+/// Extension to ``Consumer`` adding continuous pull (consume) capability.
+extension Consumer {
+
+    /// Continuously retrieves messages from the server, maintaining a buffer
+    /// that refills automatically when a threshold is reached.
+    ///
+    /// Returns a ``ConsumerMessages`` implementing ``AsyncSequence`` allowing
+    /// iteration over messages using `for try await msg in messages`.
+    ///
+    /// - Parameters:
+    ///   - config: configuration controlling buffer sizes, expiry, heartbeat
+    ///     and thresholds. Defaults to ``ConsumeConfig()``.
+    ///   - errorHandler: optional callback invoked for non-terminal warnings
+    ///     (missed heartbeats, exceeded server limits). Terminal errors are
+    ///     thrown from the iterator.
+    ///
+    /// - Returns: ``ConsumerMessages`` which implements ``AsyncSequence``.
+    ///
+    /// - Throws:
+    ///   - ``JetStreamError/ConsumeError`` for terminal errors during setup.
+    public func consume(
+        config: ConsumeConfig = ConsumeConfig(),
+        errorHandler: (@Sendable (Error) -> Void)? = nil
+    ) async throws -> ConsumerMessages {
+        // Validate config
+        if config.maxMessages != nil && config.maxBytes != nil {
+            throw JetStreamError.ConsumeError.invalidConfig(
+                "only one of maxMessages and maxBytes can be specified")
+        }
+        if let maxMessages = config.maxMessages, maxMessages < 1 {
+            throw JetStreamError.ConsumeError.invalidConfig(
+                "maxMessages must be at least 1")
+        }
+        if let maxBytes = config.maxBytes, maxBytes < 1 {
+            throw JetStreamError.ConsumeError.invalidConfig(
+                "maxBytes must be greater than 0")
+        }
+        if config.expires < 1.0 {
+            throw JetStreamError.ConsumeError.invalidConfig(
+                "expires value must be at least 1s")
+        }
+        if let hb = config.idleHeartbeat {
+            if hb < 0.5 || hb > 30.0 {
+                throw JetStreamError.ConsumeError.invalidConfig(
+                    "idleHeartbeat value must be within 500ms-30s range")
+            }
+        }
+
+        // Compute effective values
+        let expires = config.expires
+
+        let useBytes = config.maxBytes != nil
+        let effectiveMaxMessages: Int
+        let effectiveMaxBytes: Int?
+        if let maxBytes = config.maxBytes {
+            effectiveMaxMessages = 1_000_000
+            effectiveMaxBytes = maxBytes
+        } else {
+            effectiveMaxMessages = config.maxMessages ?? 500
+            effectiveMaxBytes = nil
+        }
+
+        let effectiveThresholdMessages =
+            config.thresholdMessages ?? (effectiveMaxMessages / 2)
+        let effectiveThresholdBytes: Int?
+        if let maxBytes = effectiveMaxBytes {
+            effectiveThresholdBytes = config.thresholdBytes ?? (maxBytes / 2)
+        } else {
+            effectiveThresholdBytes = nil
+        }
+
+        // Compute idle heartbeat: default expires/2, capped at 30s
+        let effectiveHeartbeat: TimeInterval
+        if let hb = config.idleHeartbeat {
+            effectiveHeartbeat = hb
+        } else {
+            effectiveHeartbeat = min(expires / 2.0, 30.0)
+        }
+        if effectiveHeartbeat > expires / 2.0 {
+            throw JetStreamError.ConsumeError.invalidConfig(
+                "idleHeartbeat must be less than 50% of expires")
+        }
+
+        let pullSubject = ctx.apiSubject(
+            "CONSUMER.MSG.NEXT.\(info.stream).\(info.name)")
+        let inbox = ctx.client.newInbox()
+        let sub = try await ctx.client.subscribe(subject: inbox)
+
+        let messages = ConsumerMessages(
+            ctx: ctx,
+            sub: sub,
+            pullSubject: pullSubject,
+            inbox: inbox,
+            maxMessages: effectiveMaxMessages,
+            maxBytes: effectiveMaxBytes,
+            expires: expires,
+            idleHeartbeat: effectiveHeartbeat,
+            thresholdMessages: effectiveThresholdMessages,
+            thresholdBytes: effectiveThresholdBytes,
+            useBytes: useBytes,
+            errorHandler: errorHandler
+        )
+
+        // Send initial pull request
+        try await messages.sendPullRequest()
+
+        // Start heartbeat monitoring
+        messages.startHeartbeatTimer()
+
+        // Register for connection events
+        messages.registerEventListeners()
+
+        return messages
+    }
+}
+
+/// Returned by ``Consumer/consume(config:errorHandler:)``.
+///
+/// Implements ``AsyncSequence`` to allow iteration over messages using
+/// `for try await msg in messages`.
+///
+/// Use ``stop()`` to discard buffered messages and end iteration, or
+/// ``drain()`` to deliver remaining buffered messages before ending.
+public final class ConsumerMessages: AsyncSequence, Sendable {
+    public typealias Element = JetStreamMessage
+    public typealias AsyncIterator = ConsumerIterator
+
+    internal let ctx: JetStreamContext
+    internal let sub: NatsSubscription
+    internal let pullSubject: String
+    internal let inbox: String
+    internal let maxMessages: Int
+    internal let maxBytes: Int?
+    internal let expires: TimeInterval
+    internal let idleHeartbeat: TimeInterval
+    internal let thresholdMessages: Int
+    internal let thresholdBytes: Int?
+    internal let useBytes: Bool
+    internal let errorHandler: (@Sendable (Error) -> Void)?
+
+    internal struct State: Sendable {
+        var pendingMessages: Int = 0
+        var pendingBytes: Int = 0
+        var stopped: Bool = false
+        var draining: Bool = false
+        var disconnected: Bool = false
+        var lastMessageNanos: UInt64 = DispatchTime.now().uptimeNanoseconds
+    }
+
+    internal let state: NIOLockedValueBox<State>
+    private let _heartbeatTask = NIOLockedValueBox<Task<Void, Never>?>(nil)
+    private let _eventListenerId = NIOLockedValueBox<String?>(nil)
+
+    internal init(
+        ctx: JetStreamContext,
+        sub: NatsSubscription,
+        pullSubject: String,
+        inbox: String,
+        maxMessages: Int,
+        maxBytes: Int?,
+        expires: TimeInterval,
+        idleHeartbeat: TimeInterval,
+        thresholdMessages: Int,
+        thresholdBytes: Int?,
+        useBytes: Bool,
+        errorHandler: (@Sendable (Error) -> Void)?
+    ) {
+        self.ctx = ctx
+        self.sub = sub
+        self.pullSubject = pullSubject
+        self.inbox = inbox
+        self.maxMessages = maxMessages
+        self.maxBytes = maxBytes
+        self.expires = expires
+        self.idleHeartbeat = idleHeartbeat
+        self.thresholdMessages = thresholdMessages
+        self.thresholdBytes = thresholdBytes
+        self.useBytes = useBytes
+        self.errorHandler = errorHandler
+        self.state = NIOLockedValueBox(State())
+    }
+
+    public func makeAsyncIterator() -> ConsumerIterator {
+        return ConsumerIterator(messages: self)
+    }
+
+    /// Stop consuming. Discards buffered messages. The iterator will return
+    /// `nil` on the next call to `next()`.
+    public func stop() {
+        state.withLockedValue { $0.stopped = true }
+        cleanup()
+    }
+
+    /// Stop fetching new messages but deliver all remaining buffered messages
+    /// before ending iteration.
+    public func drain() {
+        state.withLockedValue { $0.draining = true }
+        cancelHeartbeatTimer()
+    }
+
+    // MARK: - Internal helpers
+
+    private let jsonEncoder = JSONEncoder()
+
+    internal func sendPullRequest() async throws {
+        guard let data = try preparePullRequest() else { return }
+        try await ctx.client.publish(data, subject: pullSubject, reply: inbox)
+    }
+
+    private func preparePullRequest() throws -> Data? {
+        let (batch, maxBytesReq) = state.withLockedValue { state -> (Int, Int?) in
+            let batch: Int
+            let maxBytesReq: Int?
+            if useBytes, let maxBytes = self.maxBytes {
+                batch = self.maxMessages - state.pendingMessages
+                let remainingBytes = maxBytes - state.pendingBytes
+                maxBytesReq = Swift.max(remainingBytes, 0)
+            } else {
+                batch = self.maxMessages - state.pendingMessages
+                maxBytesReq = nil
+            }
+            // Update pending counts
+            state.pendingMessages += batch
+            if let maxBytesReq {
+                state.pendingBytes += maxBytesReq
+            }
+            return (batch, maxBytesReq)
+        }
+
+        guard batch > 0 else { return nil }
+
+        let request = PullRequest(
+            batch: batch,
+            expires: NanoTimeInterval(expires),
+            maxBytes: maxBytesReq,
+            heartbeat: NanoTimeInterval(idleHeartbeat)
+        )
+
+        return try jsonEncoder.encode(request)
+    }
+
+    internal func startHeartbeatTimer() {
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let heartbeatTimeoutNanos = UInt64(self.idleHeartbeat * 2 * 1_000_000_000)
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: heartbeatTimeoutNanos)
+                if Task.isCancelled { break }
+
+                let elapsedNanos = self.state.withLockedValue { state -> UInt64 in
+                    DispatchTime.now().uptimeNanoseconds - state.lastMessageNanos
+                }
+
+                if elapsedNanos >= heartbeatTimeoutNanos {
+                    self.errorHandler?(
+                        JetStreamError.ConsumeWarning.missedHeartbeat)
+                    // Reset pending counts and re-pull
+                    self.state.withLockedValue { state in
+                        state.pendingMessages = 0
+                        state.pendingBytes = 0
+                    }
+                    try? await self.sendPullRequest()
+                }
+            }
+        }
+        _heartbeatTask.withLockedValue { $0 = task }
+    }
+
+    internal func cancelHeartbeatTimer() {
+        _heartbeatTask.withLockedValue { task in
+            task?.cancel()
+            task = nil
+        }
+    }
+
+    internal func resetHeartbeatTime() {
+        state.withLockedValue { $0.lastMessageNanos = DispatchTime.now().uptimeNanoseconds }
+    }
+
+    internal func registerEventListeners() {
+        let listenerId = ctx.client.on([.connected, .disconnected]) {
+            [weak self] event in
+            guard let self else { return }
+            switch event {
+            case .disconnected:
+                self.state.withLockedValue { $0.disconnected = true }
+                self.cancelHeartbeatTimer()
+            case .connected:
+                let wasDraining = self.state.withLockedValue { state -> Bool in
+                    state.disconnected = false
+                    if !state.draining && !state.stopped {
+                        state.pendingMessages = 0
+                        state.pendingBytes = 0
+                    }
+                    return state.draining || state.stopped
+                }
+                if !wasDraining {
+                    self.resetHeartbeatTime()
+                    self.startHeartbeatTimer()
+                    Task {
+                        try? await self.sendPullRequest()
+                    }
+                }
+            default:
+                break
+            }
+        }
+        _eventListenerId.withLockedValue { $0 = listenerId }
+    }
+
+    private func cleanup() {
+        cancelHeartbeatTimer()
+        if let listenerId = _eventListenerId.withLockedValue({
+            let id = $0
+            $0 = nil
+            return id
+        }) {
+            ctx.client.off(listenerId)
+        }
+        Task {
+            try? await sub.unsubscribe()
+        }
+    }
+
+    /// Returns true if consuming is active (not stopped, draining, or
+    /// disconnected) and a new pull request should be sent.
+    internal func shouldRePull() -> Bool {
+        return state.withLockedValue { state in
+            !state.stopped && !state.draining && !state.disconnected
+        }
+    }
+
+    /// Calculate message size: subject + reply + headers + payload.
+    internal static func messageSize(_ message: NatsMessage) -> Int {
+        return message.subject.utf8.count
+            + (message.replySubject?.utf8.count ?? 0)
+            + message.length
+    }
+}
+
+/// Iterator for ``ConsumerMessages``.
+///
+/// Implements the ADR-37 message processing algorithm for continuous pull.
+public struct ConsumerIterator: AsyncIteratorProtocol, Sendable {
+    private let messages: ConsumerMessages
+    private var subIterator: NatsSubscription.AsyncIterator
+
+    internal init(messages: ConsumerMessages) {
+        self.messages = messages
+        self.subIterator = messages.sub.makeAsyncIterator()
+    }
+
+    /// Deferred pull flag — set in the post-message lock, checked at the
+    /// top of the next iteration before awaiting.
+    private var needsPull: Bool = false
+
+    public mutating func next() async throws -> JetStreamMessage? {
+        while true {
+            // Send deferred pull request *before* awaiting the next
+            // message so the server can start filling while we block.
+            if needsPull {
+                needsPull = false
+                try await messages.sendPullRequest()
+            }
+
+            // Await next message from subscription.
+            // If stop() was called, the subscription is closed and
+            // this returns nil immediately.
+            guard let message = try await subIterator.next() else {
+                return nil
+            }
+
+            let status = message.status ?? .ok
+
+            switch status {
+            case .idleHeartbeat:
+                messages.resetHeartbeatTime()
+                continue
+
+            case .ok:
+                // One lock per message: update pending, heartbeat, check
+                // threshold and drain. Decide on pull/drain/stopped atomically
+                // and set needsPull for the next iteration to avoid doing async
+                // work inside the lock.
+                enum Action {
+                    case deliver
+                    case deliverAndPull
+                    case drainComplete
+                    case stopped
+                }
+                let msgSize =
+                    messages.useBytes
+                    ? ConsumerMessages.messageSize(message) : 0
+                let action: Action = messages.state.withLockedValue {
+                    state -> Action in
+                    state.pendingMessages = max(state.pendingMessages - 1, 0)
+                    state.pendingBytes = max(state.pendingBytes - msgSize, 0)
+                    state.lastMessageNanos =
+                        DispatchTime.now().uptimeNanoseconds
+
+                    if state.stopped {
+                        return .stopped
+                    }
+                    if state.draining && state.pendingMessages <= 0 {
+                        return .drainComplete
+                    }
+                    if state.draining || state.disconnected {
+                        return .deliver
+                    }
+                    if messages.useBytes,
+                        let tb = messages.thresholdBytes
+                    {
+                        return state.pendingBytes <= tb
+                            ? .deliverAndPull : .deliver
+                    }
+                    return state.pendingMessages
+                        <= messages.thresholdMessages
+                        ? .deliverAndPull : .deliver
+                }
+
+                switch action {
+                case .stopped:
+                    return nil
+                case .deliver:
+                    return JetStreamMessage(
+                        message: message, client: messages.ctx.client)
+                case .deliverAndPull:
+                    needsPull = true
+                    return JetStreamMessage(
+                        message: message, client: messages.ctx.client)
+                case .drainComplete:
+                    let jsMsg = JetStreamMessage(
+                        message: message, client: messages.ctx.client)
+                    messages.stop()
+                    return jsMsg
+                }
+
+            case .timeout, .notFound, .wrongPinId:
+                // Pull request is done — adjust pending and re-pull.
+                adjustPendingAndResetHeartbeat(message)
+                if checkDrainComplete() {
+                    return nil
+                }
+                if messages.shouldRePull() {
+                    needsPull = true
+                }
+                continue
+
+            case .badRequest:
+                messages.stop()
+                throw JetStreamError.ConsumeError.badRequest
+
+            case .noResponders:
+                messages.stop()
+                throw JetStreamError.ConsumeError.noResponders
+
+            case .requestTerminated:
+                adjustPendingAndResetHeartbeat(message)
+
+                guard let description = message.description else {
+                    messages.stop()
+                    throw JetStreamError.ConsumeError.unknownStatus(
+                        status, nil)
+                }
+
+                let descLower = description.lowercased()
+
+                if descLower.contains("consumer deleted") {
+                    messages.stop()
+                    throw JetStreamError.ConsumeError.consumerDeleted
+                } else if descLower.contains("consumer is push based") {
+                    messages.stop()
+                    throw JetStreamError.ConsumeError.consumerIsPush
+                } else if descLower.contains(
+                    "message size exceeds maxbytes")
+                {
+                    if checkDrainComplete() { return nil }
+                    if messages.shouldRePull() {
+                        needsPull = true
+                    }
+                    continue
+                } else if descLower.contains("interest expired") {
+                    if checkDrainComplete() { return nil }
+                    if messages.shouldRePull() {
+                        needsPull = true
+                    }
+                    continue
+                } else if descLower.contains("exceeded maxrequestbatch") {
+                    messages.errorHandler?(
+                        JetStreamError.ConsumeWarning
+                            .exceededMaxRequestBatch(description))
+                    continue
+                } else if descLower.contains("exceeded maxrequestexpires") {
+                    messages.errorHandler?(
+                        JetStreamError.ConsumeWarning
+                            .exceededMaxRequestExpires(description))
+                    continue
+                } else if descLower.contains("exceeded maxrequestmaxbytes") {
+                    messages.errorHandler?(
+                        JetStreamError.ConsumeWarning
+                            .exceededMaxRequestMaxBytes(description))
+                    continue
+                } else if descLower.contains("exceeded maxwaiting") {
+                    messages.errorHandler?(
+                        JetStreamError.ConsumeWarning.exceededMaxWaiting(
+                            description))
+                    continue
+                }
+
+                // Unknown 409 - not terminal, just warn
+                messages.errorHandler?(
+                    JetStreamError.ConsumeError.unknownStatus(
+                        status, description))
+                continue
+
+            default:
+                adjustPendingAndResetHeartbeat(message)
+                messages.stop()
+                throw JetStreamError.ConsumeError.unknownStatus(
+                    status, message.description)
+            }
+        }
+    }
+
+    /// Check if drain is complete: draining is set and no more messages
+    /// are expected from the server.
+    private func checkDrainComplete() -> Bool {
+        let done = messages.state.withLockedValue { state -> Bool in
+            guard state.draining else { return false }
+            return state.pendingMessages <= 0
+        }
+        if done {
+            messages.stop()
+        }
+        return done
+    }
+
+    private func adjustPendingAndResetHeartbeat(_ message: NatsMessage) {
+        let headers = message.headers
+        let pendingMsgs = headers?.get(.natsPendingMessages)
+        let pendingBytes = headers?.get(.natsPendingBytes)
+        messages.state.withLockedValue { state in
+            state.lastMessageNanos = DispatchTime.now().uptimeNanoseconds
+            if let pendingMsgs,
+                let count = Int(pendingMsgs.description)
+            {
+                state.pendingMessages = max(state.pendingMessages - count, 0)
+            }
+            if let pendingBytes,
+                let bytes = Int(pendingBytes.description)
+            {
+                state.pendingBytes = max(state.pendingBytes - bytes, 0)
+            }
+        }
+    }
+}

--- a/Sources/JetStream/Consumer+Consume.swift
+++ b/Sources/JetStream/Consumer+Consume.swift
@@ -287,7 +287,13 @@ public final class ConsumerMessages: AsyncSequence, Sendable {
             return (batch, maxBytesReq)
         }
 
-        guard batch > 0 else { return nil }
+        // In bytes mode, also guard maxBytesReq > 0: NATS interprets
+        // max_bytes=0 as "no limit", which is the opposite of what we want.
+        if useBytes {
+            guard batch > 0, let req = maxBytesReq, req > 0 else { return nil }
+        } else {
+            guard batch > 0 else { return nil }
+        }
 
         let request = PullRequest(
             batch: batch,
@@ -300,6 +306,10 @@ public final class ConsumerMessages: AsyncSequence, Sendable {
     }
 
     internal func startHeartbeatTimer() {
+        _heartbeatTask.withLockedValue { task in
+            task?.cancel()
+            task = nil
+        }
         let task = Task { [weak self] in
             guard let self else { return }
             let heartbeatTimeoutNanos = UInt64(self.idleHeartbeat * 2 * 1_000_000_000)
@@ -546,21 +556,30 @@ public struct ConsumerIterator: AsyncIteratorProtocol, Sendable {
                     }
                     continue
                 } else if descLower.contains("exceeded maxrequestbatch") {
+                    // for the misconfiguration 409s do not re-pull immediately:
+                    // this error indicates the server rejected the pull because
+                    // batch size exceeds the consumer's MaxRequestBatch. Pull
+                    // will be retried after the configured idle heartbeat
+                    // interval.
+                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning
                             .exceededMaxRequestBatch(description))
                     continue
                 } else if descLower.contains("exceeded maxrequestexpires") {
+                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning
                             .exceededMaxRequestExpires(description))
                     continue
                 } else if descLower.contains("exceeded maxrequestmaxbytes") {
+                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning
                             .exceededMaxRequestMaxBytes(description))
                     continue
                 } else if descLower.contains("exceeded maxwaiting") {
+                    messages.resetHeartbeatTime()
                     messages.errorHandler?(
                         JetStreamError.ConsumeWarning.exceededMaxWaiting(
                             description))

--- a/Sources/JetStream/JetStreamError.swift
+++ b/Sources/JetStream/JetStreamError.swift
@@ -106,6 +106,59 @@ public enum JetStreamError {
 
     }
 
+    public enum ConsumeError: JetStreamErrorProtocol {
+        case invalidConfig(String)
+        case consumerDeleted
+        case consumerIsPush
+        case badRequest
+        case noResponders
+        case unknownStatus(StatusCode, String?)
+
+        public var description: String {
+            switch self {
+            case .invalidConfig(let message):
+                return "nats: \(message)"
+            case .consumerDeleted:
+                return "nats: consumer deleted"
+            case .consumerIsPush:
+                return "nats: consumer is push based"
+            case .badRequest:
+                return "nats: bad request"
+            case .noResponders:
+                return "nats: no responders"
+            case .unknownStatus(let status, let description):
+                if let description {
+                    return "nats: unknown response status: \(status): \(description)"
+                } else {
+                    return "nats: unknown response status: \(status)"
+                }
+            }
+        }
+    }
+
+    public enum ConsumeWarning: Error, CustomStringConvertible, Sendable {
+        case missedHeartbeat
+        case exceededMaxRequestBatch(String)
+        case exceededMaxRequestExpires(String)
+        case exceededMaxRequestMaxBytes(String)
+        case exceededMaxWaiting(String)
+
+        public var description: String {
+            switch self {
+            case .missedHeartbeat:
+                return "nats: missed idle heartbeat"
+            case .exceededMaxRequestBatch(let msg):
+                return "nats: \(msg)"
+            case .exceededMaxRequestExpires(let msg):
+                return "nats: \(msg)"
+            case .exceededMaxRequestMaxBytes(let msg):
+                return "nats: \(msg)"
+            case .exceededMaxWaiting(let msg):
+                return "nats: \(msg)"
+            }
+        }
+    }
+
     public enum AckError: JetStreamErrorProtocol {
         case noReplyInMessage
 

--- a/Sources/JetStream/JetStreamError.swift
+++ b/Sources/JetStream/JetStreamError.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2024-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Sources/Nats/NatsClient/NatsClient.swift
+++ b/Sources/Nats/NatsClient/NatsClient.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2024-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Sources/Nats/NatsClient/NatsClient.swift
+++ b/Sources/Nats/NatsClient/NatsClient.swift
@@ -318,7 +318,7 @@ extension NatsClient {
     /// > - ``NatsError/SubscriptionError/invalidSubject`` if the provided subject is invalid.
     /// > - ``NatsError/SubscriptionError/invalidQueue`` if the provided queue group is invalid.
     public func subscribe(subject: String, queue: String? = nil) async throws -> NatsSubscription {
-        logger.info("subscribe to subject \(subject)")
+        logger.debug("subscribe to subject \(subject)")
         guard let connectionHandler = self.connectionHandler else {
             throw NatsError.ClientError.internalError("empty connection handler")
         }

--- a/Sources/Nats/NatsHeaders.swift
+++ b/Sources/Nats/NatsHeaders.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2024-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Sources/Nats/NatsHeaders.swift
+++ b/Sources/Nats/NatsHeaders.swift
@@ -46,7 +46,8 @@ public struct NatsHeaderName: Equatable, Hashable, CustomStringConvertible, Send
     public static let natsSequence = try! NatsHeaderName("Nats-Sequence")
     public static let natsTimestamp = try! NatsHeaderName("Nats-Time-Stamp")
     public static let natsSubject = try! NatsHeaderName("Nats-Subject")
-    // Add other standard headers as needed...
+    public static let natsPendingMessages = try! NatsHeaderName("Nats-Pending-Messages")
+    public static let natsPendingBytes = try! NatsHeaderName("Nats-Pending-Bytes")
 }
 
 // Represents a NATS header map in Swift.

--- a/Sources/Nats/NatsMessage.swift
+++ b/Sources/Nats/NatsMessage.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2024-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Sources/Nats/NatsMessage.swift
+++ b/Sources/Nats/NatsMessage.swift
@@ -29,6 +29,7 @@ public struct StatusCode: Equatable, Sendable {
     public static let badRequest = StatusCode(value: 400)
     public static let notFound = StatusCode(value: 404)
     public static let timeout = StatusCode(value: 408)
+    public static let wrongPinId = StatusCode(value: 423)
     public static let noResponders = StatusCode(value: 503)
     public static let requestTerminated = StatusCode(value: 409)
 

--- a/Sources/Nats/NatsSubscription.swift
+++ b/Sources/Nats/NatsSubscription.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2024-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Sources/Nats/NatsSubscription.swift
+++ b/Sources/Nats/NatsSubscription.swift
@@ -207,7 +207,7 @@ public final class NatsSubscription: AsyncSequence, Sendable {
     /// > - ``NatsError/ClientError/connectionClosed`` if the conneciton is closed.
     /// > - ``NatsError/SubscriptionError/subscriptionClosed`` if the subscription is already closed
     public func unsubscribe(after: UInt64? = nil) async throws {
-        logger.info("unsubscribe from subject \(subject)")
+        logger.debug("unsubscribe from subject \(subject)")
         if case .closed = self.conn.currentState {
             throw NatsError.ClientError.connectionClosed
         }

--- a/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
@@ -398,28 +398,24 @@ class ConsumerConsumeTests: XCTestCase {
         let messages = try await consumer.consume(
             config: ConsumeConfig(maxMessages: 100, expires: 2))
 
-        var count = 0
-        for try await msg in messages {
-            try await msg.ack()
-            count += 1
-            if count == 5 {
-                break
+        // After reconnect, publish more messages for the consumer to pick up.
+        client.on(.connected) { _ in
+            Task {
+                for _ in 0..<5 {
+                    let ack = try await ctx.publish("foo.A", message: payload)
+                    _ = try await ack.wait()
+                }
             }
         }
-        XCTAssertEqual(count, 5)
 
         // Force reconnect — server stays up, JetStream state is preserved.
         // This tests the reconnect handler: pending reset + re-pull.
-        try await client.reconnect()
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
-        // Publish more messages after reconnect
-        for _ in 0..<5 {
-            let ack = try await ctx.publish("foo.A", message: payload)
-            _ = try await ack.wait()
+        Task {
+            try await Task.sleep(nanoseconds: 500_000_000)
+            try await client.reconnect()
         }
 
-        // Continue consuming — should receive the new messages
+        var count = 0
         for try await msg in messages {
             try await msg.ack()
             count += 1

--- a/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
@@ -28,6 +28,8 @@ class ConsumerConsumeTests: XCTestCase {
         ("testConsumeMissedHeartbeat", testConsumeMissedHeartbeat),
         ("testConsumeInvalidConfig", testConsumeInvalidConfig),
         ("testConsumeRecoverAfterTimeout", testConsumeRecoverAfterTimeout),
+        ("testConsumeReconnect", testConsumeReconnect),
+        ("testConsumeMaxBytes", testConsumeMaxBytes),
     ]
 
     var natsServer = NatsServer()
@@ -248,35 +250,24 @@ class ConsumerConsumeTests: XCTestCase {
 
         let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
 
-        var heartbeatMissed = false
+        // Delete the consumer before starting consume so the server never
+        // sets up heartbeat monitoring for the pull request. This guarantees
+        // no heartbeats arrive and the client's timer detects the miss.
+        try await stream.deleteConsumer(name: "cons")
+
+        let heartbeatExpectation = XCTestExpectation(
+            description: "missed heartbeat should be reported")
         let messages = try await consumer.consume(
-            config: ConsumeConfig(maxMessages: 10, expires: 3, idleHeartbeat: 1),
+            config: ConsumeConfig(maxMessages: 10, expires: 2, idleHeartbeat: 0.5),
             errorHandler: { error in
                 if case JetStreamError.ConsumeWarning.missedHeartbeat = error {
-                    heartbeatMissed = true
+                    heartbeatExpectation.fulfill()
                 }
             }
         )
 
-        // Delete consumer to stop heartbeats, then wait for timeout
-        try await stream.deleteConsumer(name: "cons")
-
-        do {
-            for try await _ in messages {
-                break
-            }
-        } catch {
-            // Expected - consumer deleted or heartbeat missed
-        }
-
-        // Wait for heartbeat timer to fire
-        try await Task.sleep(nanoseconds: 3_000_000_000)
+        await fulfillment(of: [heartbeatExpectation], timeout: 5.0)
         messages.stop()
-
-        // Heartbeat should have been reported as missed
-        // Note: depending on timing, the consumer deleted error may
-        // arrive before the heartbeat timer fires
-        XCTAssertTrue(heartbeatMissed || true, "heartbeat miss detection is timing-dependent")
     }
 
     func testConsumeInvalidConfig() async throws {
@@ -382,6 +373,99 @@ class ConsumerConsumeTests: XCTestCase {
             }
         }
         XCTAssertEqual(count, 10)
+    }
+
+    func testConsumeReconnect() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<5 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 100, expires: 2))
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            count += 1
+            if count == 5 {
+                break
+            }
+        }
+        XCTAssertEqual(count, 5)
+
+        // Force reconnect — server stays up, JetStream state is preserved.
+        // This tests the reconnect handler: pending reset + re-pull.
+        try await client.reconnect()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        // Publish more messages after reconnect
+        for _ in 0..<5 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        // Continue consuming — should receive the new messages
+        for try await msg in messages {
+            try await msg.ack()
+            count += 1
+            if count == 10 {
+                messages.stop()
+            }
+        }
+        XCTAssertEqual(count, 10)
+    }
+
+    func testConsumeMaxBytes() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<20 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        // Use maxBytes instead of maxMessages
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxBytes: 4096, expires: 5))
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            XCTAssertEqual(msg.payload, payload)
+            count += 1
+            if count == 20 {
+                messages.stop()
+            }
+        }
+        XCTAssertEqual(count, 20)
     }
 
     private func assertConsumeInvalidConfig(

--- a/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
@@ -60,8 +60,7 @@ class ConsumerConsumeTests: XCTestCase {
             _ = try await ack.wait()
         }
 
-        let messages = try await consumer.consume(
-            config: ConsumeConfig(maxMessages: 100, expires: 5))
+        let messages = try await consumer.consume()
 
         var count = 0
         for try await msg in messages {

--- a/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerConsumeTests.swift
@@ -1,0 +1,405 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JetStream
+import Logging
+import Nats
+import NatsServer
+import XCTest
+
+class ConsumerConsumeTests: XCTestCase {
+
+    static var allTests = [
+        ("testConsumeBasic", testConsumeBasic),
+        ("testConsumeStop", testConsumeStop),
+        ("testConsumeDrain", testConsumeDrain),
+        ("testConsumeConsumerDeleted", testConsumeConsumerDeleted),
+        ("testConsumeRePull", testConsumeRePull),
+        ("testConsumeMissedHeartbeat", testConsumeMissedHeartbeat),
+        ("testConsumeInvalidConfig", testConsumeInvalidConfig),
+        ("testConsumeRecoverAfterTimeout", testConsumeRecoverAfterTimeout),
+    ]
+
+    var natsServer = NatsServer()
+
+    override func tearDown() {
+        super.tearDown()
+        natsServer.stop()
+    }
+
+    func testConsumeBasic() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<50 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 100, expires: 5))
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            XCTAssertEqual(msg.payload, payload)
+            count += 1
+            if count == 50 {
+                messages.stop()
+            }
+        }
+        XCTAssertEqual(count, 50)
+    }
+
+    func testConsumeStop() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<100 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 100, expires: 5))
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            count += 1
+            if count == 10 {
+                // Stop after 10 messages - should discard the rest
+                messages.stop()
+            }
+        }
+        // Should have received exactly 10 messages before stop took effect
+        XCTAssertEqual(count, 10)
+    }
+
+    func testConsumeDrain() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<20 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 100, expires: 5))
+
+        // Give time for all messages to arrive in buffer
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Call drain - should deliver buffered messages then end
+        messages.drain()
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            count += 1
+        }
+        // Should have received all 20 messages during drain
+        XCTAssertEqual(count, 20)
+    }
+
+    func testConsumeConsumerDeleted() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<5 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 100, expires: 5))
+
+        // Delete the consumer after a brief delay
+        Task {
+            try await Task.sleep(nanoseconds: 500_000_000)
+            try await stream.deleteConsumer(name: "cons")
+        }
+
+        var count = 0
+        do {
+            for try await msg in messages {
+                try await msg.ack()
+                count += 1
+            }
+        } catch JetStreamError.ConsumeError.consumerDeleted {
+            // Expected - consumer was deleted
+            XCTAssertEqual(count, 5)
+            return
+        }
+        XCTFail("should get consumer deleted error")
+    }
+
+    func testConsumeRePull() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        // Use a small buffer to force re-pulls
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 10, expires: 5, thresholdMessages: 5))
+
+        // Publish messages in batches to test re-pull
+        let payload = "hello".data(using: .utf8)!
+
+        // Publish first batch
+        for _ in 0..<30 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            count += 1
+            if count == 30 {
+                messages.stop()
+            }
+        }
+        // Should have received all 30 messages across multiple re-pulls
+        XCTAssertEqual(count, 30)
+    }
+
+    func testConsumeMissedHeartbeat() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        var heartbeatMissed = false
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(maxMessages: 10, expires: 3, idleHeartbeat: 1),
+            errorHandler: { error in
+                if case JetStreamError.ConsumeWarning.missedHeartbeat = error {
+                    heartbeatMissed = true
+                }
+            }
+        )
+
+        // Delete consumer to stop heartbeats, then wait for timeout
+        try await stream.deleteConsumer(name: "cons")
+
+        do {
+            for try await _ in messages {
+                break
+            }
+        } catch {
+            // Expected - consumer deleted or heartbeat missed
+        }
+
+        // Wait for heartbeat timer to fire
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+        messages.stop()
+
+        // Heartbeat should have been reported as missed
+        // Note: depending on timing, the consumer deleted error may
+        // arrive before the heartbeat timer fires
+        XCTAssertTrue(heartbeatMissed || true, "heartbeat miss detection is timing-dependent")
+    }
+
+    func testConsumeInvalidConfig() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        // maxMessages and maxBytes are mutually exclusive
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(maxMessages: 100, maxBytes: 1024),
+            expectedMessage: "only one of maxMessages and maxBytes can be specified"
+        )
+
+        // maxMessages must be at least 1
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(maxMessages: 0),
+            expectedMessage: "maxMessages must be at least 1"
+        )
+
+        // maxBytes must be greater than 0
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(maxBytes: 0),
+            expectedMessage: "maxBytes must be greater than 0"
+        )
+
+        // expires must be at least 1s
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(expires: 0.5),
+            expectedMessage: "expires value must be at least 1s"
+        )
+
+        // idleHeartbeat must be within 500ms-30s range
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(idleHeartbeat: 0.1),
+            expectedMessage: "idleHeartbeat value must be within 500ms-30s range"
+        )
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(idleHeartbeat: 31),
+            expectedMessage: "idleHeartbeat value must be within 500ms-30s range"
+        )
+
+        // idleHeartbeat must be less than 50% of expires
+        try await assertConsumeInvalidConfig(
+            consumer,
+            config: ConsumeConfig(expires: 4, idleHeartbeat: 3),
+            expectedMessage: "idleHeartbeat must be less than 50% of expires"
+        )
+    }
+
+    func testConsumeRecoverAfterTimeout() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        // Start consuming with a short expires BEFORE any messages are published.
+        // The first pull will expire (408 timeout) with no messages delivered.
+        // After the timeout, consume must re-pull and pick up newly published messages.
+        let messages = try await consumer.consume(
+            config: ConsumeConfig(expires: 2, idleHeartbeat: 0.5))
+
+        // Wait for the first pull request to expire
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+
+        // Now publish messages — these should be picked up by the re-pull
+        let payload = "hello".data(using: .utf8)!
+        for _ in 0..<10 {
+            let ack = try await ctx.publish("foo.A", message: payload)
+            _ = try await ack.wait()
+        }
+
+        var count = 0
+        for try await msg in messages {
+            try await msg.ack()
+            count += 1
+            if count == 10 {
+                messages.stop()
+            }
+        }
+        XCTAssertEqual(count, 10)
+    }
+
+    private func assertConsumeInvalidConfig(
+        _ consumer: Consumer,
+        config: ConsumeConfig,
+        expectedMessage: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        do {
+            _ = try await consumer.consume(config: config)
+            XCTFail("should throw invalidConfig error", file: file, line: line)
+        } catch let error as JetStreamError.ConsumeError {
+            guard case .invalidConfig(let message) = error else {
+                XCTFail("expected invalidConfig, got \(error)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(message, expectedMessage, file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
- Implement `Consumer.consume()` per ADR-37 with auto-refilling buffer, heartbeat monitoring, reconnect recovery, and strict config validation
- `ConsumerMessages` implements `AsyncSequence` for idiomatic `for try await msg in messages` iteration
- Automatic re-pull when buffer drops below threshold, with immediate re-pull after pull-terminating statuses (timeout, notFound, wrongPinId, message size exceeds maxbytes, interest expired)
- Heartbeat timer detects missed heartbeats and re-pulls; reconnect handler resets pending counts


Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)