### PR TITLE
Fix reliability gaps in the JetStream pull consumer and reconnect handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ playground.xcworkspace
 # Package.pins
 Package.resolved
 .build/
+.build-linux/
 
 # CocoaPods
 #

--- a/Sources/JetStream/Consumer+Pull.swift
+++ b/Sources/JetStream/Consumer+Pull.swift
@@ -45,150 +45,215 @@ extension Consumer {
         let subject = ctx.apiSubject("CONSUMER.MSG.NEXT.\(info.stream).\(info.name)")
         let inbox = ctx.client.newInbox()
         let sub = try await ctx.client.subscribe(subject: inbox)
-        try await self.ctx.client.publish(
-            JSONEncoder().encode(request), subject: subject, reply: inbox)
-        return FetchResult(ctx: ctx, sub: sub, idleHeartbeat: idleHeartbeat, batch: batch)
+        do {
+            try await self.ctx.client.publish(
+                JSONEncoder().encode(request), subject: subject, reply: inbox)
+        } catch {
+            try? await sub.unsubscribe()
+            throw error
+        }
+        return FetchResult(
+            ctx: ctx, sub: sub, idleHeartbeat: idleHeartbeat, batch: batch, expires: expires)
     }
 }
 
-/// Used to iterate over results of ``Consumer/fetch(batch:expires:idleHeartbeat:)``
-public class FetchResult: AsyncSequence {
+/// Used to iterate over results of ``Consumer/fetch(batch:expires:idleHeartbeat:)``.
+public final class FetchResult: AsyncSequence, Sendable {
     public typealias Element = JetStreamMessage
-    public typealias AsyncIterator = FetchIterator
+    public typealias AsyncIterator = AsyncThrowingStream<JetStreamMessage, Error>.Iterator
 
+    private let stream: AsyncThrowingStream<JetStreamMessage, Error>
+
+    init(
+        ctx: JetStreamContext, sub: NatsSubscription, idleHeartbeat: TimeInterval?, batch: Int,
+        expires: TimeInterval
+    ) {
+        self.stream = AsyncThrowingStream { continuation in
+            let producerTask = Task {
+                let producer = FetchProducer(
+                    ctx: ctx, sub: sub, idleHeartbeat: idleHeartbeat, remaining: batch,
+                    expires: expires)
+                await producer.run(into: continuation)
+            }
+            continuation.onTermination = { _ in
+                producerTask.cancel()
+                Task { await FetchResult.tearDownIgnoringClosed(sub) }
+            }
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        stream.makeAsyncIterator()
+    }
+
+    private static func tearDownIgnoringClosed(_ sub: NatsSubscription) async {
+        do {
+            try await sub.unsubscribe()
+        } catch NatsError.SubscriptionError.subscriptionClosed,
+            NatsError.ClientError.connectionClosed
+        {
+        } catch {
+            logger.error("error tearing down fetch subscription: \(error)")
+        }
+    }
+}
+
+private struct FetchProducer {
     private let ctx: JetStreamContext
-    private let sub: NatsSubscription
     private let idleHeartbeat: TimeInterval?
-    private let batch: Int
+    private let remaining: Int
+    private let deadlineUptime: TimeInterval
+    private let subIterator: NatsSubscription.AsyncIterator
 
-    init(ctx: JetStreamContext, sub: NatsSubscription, idleHeartbeat: TimeInterval?, batch: Int) {
+    private static let deadlineGrace: TimeInterval = 1
+
+    init(
+        ctx: JetStreamContext, sub: NatsSubscription, idleHeartbeat: TimeInterval?, remaining: Int,
+        expires: TimeInterval
+    ) {
         self.ctx = ctx
-        self.sub = sub
         self.idleHeartbeat = idleHeartbeat
-        self.batch = batch
+        self.remaining = remaining
+        self.subIterator = sub.makeAsyncIterator()
+        self.deadlineUptime =
+            ProcessInfo.processInfo.systemUptime + expires + Self.deadlineGrace
     }
 
-    public func makeAsyncIterator() -> FetchIterator {
-        return FetchIterator(
-            ctx: ctx,
-            sub: self.sub, idleHeartbeat: self.idleHeartbeat, remainingMessages: self.batch)
+    private enum ReadOutcome {
+        case message(NatsMessage)
+        case subscriptionEnded
+        case missedHeartbeat
     }
 
-    public struct FetchIterator: AsyncIteratorProtocol {
-        private let ctx: JetStreamContext
-        private let sub: NatsSubscription
-        private let idleHeartbeat: TimeInterval?
-        private var remainingMessages: Int
-        private var subIterator: NatsSubscription.AsyncIterator
+    private enum MessageOutcome {
+        case deliver(JetStreamMessage)
+        case skip
+        case end
+    }
 
-        init(
-            ctx: JetStreamContext, sub: NatsSubscription, idleHeartbeat: TimeInterval?,
-            remainingMessages: Int
-        ) {
-            self.ctx = ctx
-            self.sub = sub
-            self.idleHeartbeat = idleHeartbeat
-            self.remainingMessages = remainingMessages
-            self.subIterator = sub.makeAsyncIterator()
-        }
+    fileprivate typealias Continuation = AsyncThrowingStream<JetStreamMessage, Error>.Continuation
 
-        public mutating func next() async throws -> JetStreamMessage? {
-            if remainingMessages <= 0 {
-                try await sub.unsubscribe()
-                return nil
+    func run(into continuation: Continuation) async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await self.finishAtDeadline(continuation) }
+            group.addTask { [subIterator, ctx, idleHeartbeat, remaining] in
+                await Self.readLoop(
+                    subIterator: subIterator, ctx: ctx, idleHeartbeat: idleHeartbeat,
+                    remaining: remaining, into: continuation)
             }
+            await group.next()
+            group.cancelAll()
+        }
+    }
 
-            while true {
-                let message: NatsMessage?
+    private func finishAtDeadline(_ continuation: Continuation) async {
+        let nanos = Self.nanoseconds(
+            max(0, deadlineUptime - ProcessInfo.processInfo.systemUptime))
+        try? await Task.sleep(nanoseconds: nanos)
+        continuation.finish()
+    }
 
-                if let idleHeartbeat = idleHeartbeat {
-                    let timeout = idleHeartbeat * 2
-                    message = try await nextWithTimeout(timeout, subIterator)
-                } else {
-                    message = try await subIterator.next()
+    private static func readLoop(
+        subIterator: NatsSubscription.AsyncIterator, ctx: JetStreamContext,
+        idleHeartbeat: TimeInterval?, remaining: Int, into continuation: Continuation
+    ) async {
+        var remaining = remaining
+        do {
+            while remaining > 0 {
+                let message: NatsMessage
+                switch try await readNextMessage(
+                    subIterator: subIterator, idleHeartbeat: idleHeartbeat)
+                {
+                case .message(let received):
+                    message = received
+                case .subscriptionEnded:
+                    continuation.finish()
+                    return
+                case .missedHeartbeat:
+                    continuation.finish(throwing: JetStreamError.FetchError.noHeartbeatReceived)
+                    return
                 }
-
-                guard let message else {
-                    // the subscription has ended
-                    try await sub.unsubscribe()
-                    return nil
-                }
-
-                let status = message.status ?? .ok
-
-                switch status {
-                case .timeout:
-                    try await sub.unsubscribe()
-                    return nil
-                case .idleHeartbeat:
-                    // in case of idle heartbeat error, we want to
-                    // wait for next message on subscription
+                switch try handle(message, ctx: ctx) {
+                case .deliver(let jsMessage):
+                    remaining -= 1
+                    continuation.yield(jsMessage)
+                case .skip:
                     continue
-                case .notFound:
-                    try await sub.unsubscribe()
-                    return nil
-                case .ok:
-                    remainingMessages -= 1
-                    return JetStreamMessage(message: message, client: ctx.client)
-                case .badRequest:
-                    try await sub.unsubscribe()
-                    throw JetStreamError.FetchError.badRequest
-                case .noResponders:
-                    try await sub.unsubscribe()
-                    throw JetStreamError.FetchError.noResponders
-                case .requestTerminated:
-                    try await sub.unsubscribe()
-                    guard let description = message.description else {
-                        throw JetStreamError.FetchError.invalidResponse
-                    }
-
-                    let descLower = description.lowercased()
-                    if descLower.contains("message size exceeds maxbytes") {
-                        return nil
-                    } else if descLower.contains("leadership changed") {
-                        throw JetStreamError.FetchError.leadershipChanged
-                    } else if descLower.contains("consumer deleted") {
-                        throw JetStreamError.FetchError.consumerDeleted
-                    } else if descLower.contains("consumer is push based") {
-                        throw JetStreamError.FetchError.consumerIsPush
-                    }
-                default:
-                    throw JetStreamError.FetchError.unknownStatus(status, message.description)
+                case .end:
+                    continuation.finish()
+                    return
                 }
-
-                if remainingMessages == 0 {
-                    try await sub.unsubscribe()
-                }
-
             }
+            continuation.finish()
+        } catch {
+            continuation.finish(throwing: error)
         }
+    }
 
-        func nextWithTimeout(
-            _ timeout: TimeInterval, _ subIterator: NatsSubscription.AsyncIterator
-        ) async throws -> NatsMessage? {
-            try await withThrowingTaskGroup(of: NatsMessage?.self) { group in
-                group.addTask {
-                    return try await subIterator.next()
-                }
-                group.addTask {
-                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                    try await sub.unsubscribe()
-                    return nil
-                }
-                defer {
-                    group.cancelAll()
-                }
-                for try await result in group {
-                    if let msg = result {
-                        return msg
-                    } else {
-                        throw JetStreamError.FetchError.noHeartbeatReceived
-                    }
-                }
-                // this should not be reachable
-                throw JetStreamError.FetchError.noHeartbeatReceived
+    private static func readNextMessage(
+        subIterator: NatsSubscription.AsyncIterator, idleHeartbeat: TimeInterval?
+    ) async throws -> ReadOutcome {
+        guard let heartbeatNanos = idleHeartbeat.map({ nanoseconds($0 * 2) }) else {
+            if let message = try await subIterator.next() {
+                return .message(message)
             }
+            return .subscriptionEnded
         }
+        return try await withThrowingTaskGroup(of: ReadOutcome.self) { group in
+            group.addTask {
+                if let message = try await subIterator.next() {
+                    return .message(message)
+                }
+                return .subscriptionEnded
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: heartbeatNanos)
+                return .missedHeartbeat
+            }
+            defer { group.cancelAll() }
+            return try await group.next() ?? .subscriptionEnded
+        }
+    }
+
+    private static func handle(
+        _ message: NatsMessage, ctx: JetStreamContext
+    ) throws
+        -> MessageOutcome
+    {
+        switch message.status ?? .ok {
+        case .ok:
+            return .deliver(JetStreamMessage(message: message, client: ctx.client))
+        case .idleHeartbeat:
+            return .skip
+        case .timeout, .notFound:
+            return .end
+        case .badRequest:
+            throw JetStreamError.FetchError.badRequest
+        case .noResponders:
+            throw JetStreamError.FetchError.noResponders
+        case .requestTerminated:
+            guard let description = message.description else {
+                throw JetStreamError.FetchError.invalidResponse
+            }
+            let descLower = description.lowercased()
+            if descLower.contains("leadership changed") {
+                throw JetStreamError.FetchError.leadershipChanged
+            } else if descLower.contains("consumer deleted") {
+                throw JetStreamError.FetchError.consumerDeleted
+            } else if descLower.contains("consumer is push based") {
+                throw JetStreamError.FetchError.consumerIsPush
+            }
+            return .end
+        default:
+            throw JetStreamError.FetchError.unknownStatus(
+                message.status ?? .ok, message.description)
+        }
+    }
+
+    private static func nanoseconds(_ seconds: TimeInterval) -> UInt64 {
+        let ns = (seconds * 1_000_000_000).rounded()
+        guard ns > 0 else { return 0 }
+        return ns >= Double(UInt64.max) ? .max : UInt64(ns)
     }
 }
 

--- a/Sources/JetStream/JetStreamContext+Consumer.swift
+++ b/Sources/JetStream/JetStreamContext+Consumer.swift
@@ -142,7 +142,7 @@ extension JetStreamContext {
         try Consumer.validate(name: consumerName)
 
         let createReq = CreateConsumerRequest(stream: stream, config: cfg, action: action)
-        let req = try! JSONEncoder().encode(createReq)
+        let req = try JSONEncoder().encode(createReq)
 
         var subject: String
         if let filterSubject = cfg.filterSubject {

--- a/Sources/JetStream/JetStreamContext+Stream.swift
+++ b/Sources/JetStream/JetStreamContext+Stream.swift
@@ -33,7 +33,7 @@ extension JetStreamContext {
     /// > - ``JetStreamError/APIError``: if there was a different API error returned from JetStream.
     public func createStream(cfg: StreamConfig) async throws -> Stream {
         try Stream.validate(name: cfg.name)
-        let req = try! JSONEncoder().encode(cfg)
+        let req = try JSONEncoder().encode(cfg)
         let subj = "STREAM.CREATE.\(cfg.name)"
         let info: Response<StreamInfo> = try await request(subj, message: req)
         switch info {
@@ -93,7 +93,7 @@ extension JetStreamContext {
     /// > - ``JetStreamError/APIError`` if there was a different API error returned from JetStream.
     public func updateStream(cfg: StreamConfig) async throws -> Stream {
         try Stream.validate(name: cfg.name)
-        let req = try! JSONEncoder().encode(cfg)
+        let req = try JSONEncoder().encode(cfg)
         let subj = "STREAM.UPDATE.\(cfg.name)"
         let info: Response<StreamInfo> = try await request(subj, message: req)
         switch info {

--- a/Sources/Nats/BatchBuffer.swift
+++ b/Sources/Nats/BatchBuffer.swift
@@ -43,8 +43,8 @@ extension BatchBuffer {
             return writeBuffer
         }
 
-        mutating func writeMessage(_ message: ClientOp) {
-            self.buffer.writeClientOp(message)
+        mutating func writeMessage(_ message: ClientOp) throws {
+            try self.buffer.writeClientOp(message)
         }
     }
 }
@@ -64,7 +64,8 @@ internal final class BatchBuffer: Sendable {
 
     func writeMessage(_ message: ClientOp) async throws {
         #if SWIFT_NATS_BATCH_BUFFER_DISABLED
-            let b = channel.allocator.buffer(bytes: data)
+            var b = channel.allocator.buffer(capacity: 0)
+            try b.writeClientOp(message)
             try await channel.writeAndFlush(b)
         #else
             // Batch writes and if we have more than the batch size
@@ -77,7 +78,12 @@ internal final class BatchBuffer: Sendable {
                         return
                     }
 
-                    state.writeMessage(message)
+                    do {
+                        try state.writeMessage(message)
+                    } catch {
+                        continuation.resume(throwing: error)
+                        return
+                    }
                     self.flushWhenIdle(state: &state)
                     continuation.resume()
                 }
@@ -104,8 +110,12 @@ internal final class BatchBuffer: Sendable {
                 switch result {
                 case .success:
                     for (message, continuation) in state.waitingPromises {
-                        state.writeMessage(message)
-                        continuation.resume()
+                        do {
+                            try state.writeMessage(message)
+                            continuation.resume()
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
                     }
                     state.waitingPromises.removeAll()
                 case .failure(let error):

--- a/Sources/Nats/Extensions/ByteBuffer+Writer.swift
+++ b/Sources/Nats/Extensions/ByteBuffer+Writer.swift
@@ -15,7 +15,7 @@ import Foundation
 import NIO
 
 extension ByteBuffer {
-    mutating func writeClientOp(_ op: ClientOp) {
+    mutating func writeClientOp(_ op: ClientOp) throws {
         switch op {
         case .publish((let subject, let reply, let payload, let headers)):
             if let payload = payload {
@@ -72,8 +72,7 @@ extension ByteBuffer {
                 self.writeString("\(NatsOperation.unsubscribe.rawValue) \(sid)\r\n")
             }
         case .connect(let info):
-            // This encode can't actually fail
-            let json = try! JSONEncoder().encode(info)
+            let json = try JSONEncoder().encode(info)
             self.reserveCapacity(minimumWritableBytes: json.count + 5)
             self.writeString("\(NatsOperation.connect.rawValue) ")
             self.writeData(json)

--- a/Sources/Nats/NatsClient/NatsClient.swift
+++ b/Sources/Nats/NatsClient/NatsClient.swift
@@ -328,6 +328,18 @@ extension NatsClient {
         return try await connectionHandler.subscribe(subject, queue: queue)
     }
 
+    internal func subscribe(
+        subject: String, queue: String? = nil, capacity: UInt64
+    ) async throws -> NatsSubscription {
+        guard let connectionHandler = self.connectionHandler else {
+            throw NatsError.ClientError.internalError("empty connection handler")
+        }
+        if case .closed = connectionHandler.currentState {
+            throw NatsError.ClientError.connectionClosed
+        }
+        return try await connectionHandler.subscribe(subject, queue: queue, capacity: capacity)
+    }
+
     /// Sends a PING to the server, returning the time it took for the server to respond.
     ///
     /// - Returns rtt of the request.

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -314,11 +314,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
         let natsMsg = NatsMessage(
             payload: message.payload, subject: message.subject, replySubject: message.reply,
             length: message.length, headers: nil, status: nil, description: nil)
-        subscriptions.withLockedValue { subs in
-            if let sub = subs[message.sid] {
-                sub.receiveMessage(natsMsg)
-            }
-        }
+        deliverOutsideLock(natsMsg, toSid: message.sid)
     }
 
     private func handleIncomingMessage(_ message: HMessageInbound) {
@@ -326,11 +322,12 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
             payload: message.payload, subject: message.subject, replySubject: message.reply,
             length: message.length, headers: message.headers, status: message.status,
             description: message.description)
-        subscriptions.withLockedValue { subs in
-            if let sub = subs[message.sid] {
-                sub.receiveMessage(natsMsg)
-            }
-        }
+        deliverOutsideLock(natsMsg, toSid: message.sid)
+    }
+
+    private func deliverOutsideLock(_ natsMsg: NatsMessage, toSid sid: UInt64) {
+        let sub = subscriptions.withLockedValue { $0[sid] }
+        sub?.receiveMessage(natsMsg)
     }
 
     func connect() async throws {
@@ -1047,11 +1044,17 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
     }
 
     internal func subscribe(
-        _ subject: String, queue: String? = nil
+        _ subject: String, queue: String? = nil, capacity: UInt64? = nil
     ) async throws -> NatsSubscription {
         let sid = self.subscriptionCounter.wrappingIncrementThenLoad(
             ordering: AtomicUpdateOrdering.relaxed)
-        let sub = try NatsSubscription(sid: sid, subject: subject, queue: queue, conn: self)
+        let sub: NatsSubscription
+        if let capacity {
+            sub = try NatsSubscription(
+                sid: sid, subject: subject, queue: queue, capacity: max(1, capacity), conn: self)
+        } else {
+            sub = try NatsSubscription(sid: sid, subject: subject, queue: queue, conn: self)
+        }
 
         // Add subscription BEFORE sending command to avoid race condition
         subscriptions.withLockedValue { $0[sid] = sub }

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -1042,6 +1042,10 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
         }
     }
 
+    internal var subscriptionCount: Int {
+        subscriptions.withLockedValue { $0.count }
+    }
+
     internal func subscribe(
         _ subject: String, queue: String? = nil
     ) async throws -> NatsSubscription {

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -402,6 +402,9 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
                 throw NatsError.ConnectError.io(lastErr)
             }
         }
+        // Restore before clearing the counter so a restore failure stays bounded by
+        // maxReconnects (no-op on the initial connect: the set is empty).
+        try await restoreSubscriptions()
         self.reconnectAttempts = 0
         guard let channel = self.channel else {
             throw NatsError.ClientError.internalError("empty channel")
@@ -1011,21 +1014,35 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
-            // Recreate subscriptions - safely copy first
-            let subsToRestore = subscriptions.withLockedValue { Array($0) }
-            for (sid, sub) in subsToRestore {
-                do {
-                    try await write(operation: ClientOp.subscribe((sid, sub.subject, nil)))
-                } catch {
-                    logger.error("Error recreating subscription \(sid): \(error)")
-                }
-            }
-
             self.channel?.eventLoop.execute {
                 self.state.withLockedValue { $0 = .connected }
                 self.fire(.connected)
             }
         }
+    }
+
+    private func restoreSubscriptions() async throws {
+        let subsToRestore = subscriptions.withLockedValue { Array($0) }
+        for (sid, sub) in subsToRestore {
+            do {
+                try await resubscribe(sid: sid, sub)
+            } catch {
+                logger.error("Error recreating subscription \(sid): \(error)")
+                self.fire(.error((error as? NatsErrorProtocol) ?? NatsError.ClientError.io(error)))
+                throw error
+            }
+        }
+    }
+
+    private func resubscribe(sid: UInt64, _ sub: NatsSubscription) async throws {
+        guard let max = sub.max else {
+            try await write(operation: ClientOp.subscribe((sid, sub.subject, sub.queue)))
+            return
+        }
+        let receivedSoFar = sub.received
+        guard receivedSoFar < max else { return }
+        try await write(operation: ClientOp.subscribe((sid, sub.subject, sub.queue)))
+        try await write(operation: ClientOp.unsubscribe((sid: sid, max: max - receivedSoFar)))
     }
 
     func write(operation: ClientOp) async throws {

--- a/Sources/Nats/NatsError.swift
+++ b/Sources/Nats/NatsError.swift
@@ -215,6 +215,7 @@ public enum NatsError {
         case invalidQueue
         case permissionDenied
         case subscriptionClosed
+        case slowConsumer
 
         public var description: String {
             switch self {
@@ -226,6 +227,8 @@ public enum NatsError {
                 return "nats: permission denied"
             case .subscriptionClosed:
                 return "nats: subscription closed"
+            case .slowConsumer:
+                return "nats: slow consumer, messages dropped"
             }
         }
     }

--- a/Sources/Nats/NatsSubscription.swift
+++ b/Sources/Nats/NatsSubscription.swift
@@ -15,7 +15,6 @@ import Foundation
 import NIOConcurrencyHelpers
 import NIOCore
 
-// TODO(pp): Implement slow consumer
 public final class NatsSubscription: AsyncSequence, Sendable {
     public typealias Element = NatsMessage
     public typealias AsyncIterator = SubscriptionIterator
@@ -31,14 +30,23 @@ public final class NatsSubscription: AsyncSequence, Sendable {
     internal var delivered: UInt64 {
         state.withLockedValue { $0.delivered }
     }
+    internal var received: UInt64 {
+        state.withLockedValue { $0.received }
+    }
     internal let sid: UInt64
 
     private struct State: Sendable {
         var buffer: [Result<NatsMessage, NatsError.SubscriptionError>] = []
         var closed = false
         var delivered: UInt64 = 0
+        var received: UInt64 = 0
+        var slowConsumer = false
         var continuation:
             CheckedContinuation<Result<NatsMessage, NatsError.SubscriptionError>?, Never>? = nil
+
+        mutating func rearmSlowConsumerBelowHalfCapacity(capacity: UInt64) {
+            if buffer.count <= capacity / 2 { slowConsumer = false }
+        }
     }
 
     private let state = NIOLockedValueBox(State())
@@ -74,24 +82,31 @@ public final class NatsSubscription: AsyncSequence, Sendable {
     }
 
     func receiveMessage(_ message: NatsMessage) {
+        var didBecomeSlowConsumer = false
         let continuationToResume:
             CheckedContinuation<Result<NatsMessage, NatsError.SubscriptionError>?, Never>? =
                 state.withLockedValue { state in
                     if let continuation = state.continuation {
                         state.continuation = nil
+                        state.received += 1
                         return continuation
 
                     } else if state.buffer.count < capacity {
                         // Only append to buffer if no continuation is available
-                        // TODO(pp): Handle SlowConsumer as subscription event
                         state.buffer.append(.success(message))
+                        state.received += 1
                     } else {
-                        // Slow consumer: message dropped intentionally.
-                        // TODO: emit SlowConsumer subscription event.
+                        if !state.slowConsumer {
+                            state.slowConsumer = true
+                            didBecomeSlowConsumer = true
+                        }
                     }
                     return nil
                 }
 
+        if didBecomeSlowConsumer {
+            conn.fire(.error(NatsError.SubscriptionError.slowConsumer))
+        }
         continuationToResume?.resume(returning: .success(message))
     }
 
@@ -153,12 +168,9 @@ public final class NatsSubscription: AsyncSequence, Sendable {
                             return .resume(nil)
                         }
 
-                        // delivered tracks "slots consumed", not "messages returned".
-                        // It is incremented here — before the message is in hand.
-                        state.delivered += 1
-
                         if let message = state.buffer.first {
                             state.buffer.removeFirst()
+                            state.rearmSlowConsumerBelowHalfCapacity(capacity: capacity)
                             return .resume(message)
                         } else {
                             state.continuation = continuation
@@ -183,7 +195,10 @@ public final class NatsSubscription: AsyncSequence, Sendable {
                 continuationToResume?.resume(returning: nil)
             }
 
-        let delivered = state.withLockedValue { $0.delivered }
+        let delivered: UInt64 = state.withLockedValue { state in
+            if case .success? = result { state.delivered += 1 }
+            return state.delivered
+        }
         if let max, delivered >= max {
             conn.removeSub(sub: self)
         }

--- a/Tests/JetStreamTests/Integration/ConsumerTests.swift
+++ b/Tests/JetStreamTests/Integration/ConsumerTests.swift
@@ -13,9 +13,10 @@
 
 import JetStream
 import Logging
-import Nats
 import NatsServer
 import XCTest
+
+@testable import Nats
 
 class ConsumerTests: XCTestCase {
 
@@ -28,6 +29,10 @@ class ConsumerTests: XCTestCase {
         ("testNak", testNak),
         ("testNakWithDelay", testNakWithDelay),
         ("testTerm", testTerm),
+        ("testFetchEmptyTerminatesWithoutHang", testFetchEmptyTerminatesWithoutHang),
+        ("testFetchCancellationTearsDownSubscription", testFetchCancellationTearsDownSubscription),
+        ("testFetchEarlyBreakTearsDownSubscription", testFetchEarlyBreakTearsDownSubscription),
+        ("testFetchCompletionTearsDownSubscription", testFetchCompletionTearsDownSubscription),
     ]
 
     var natsServer = NatsServer()
@@ -419,5 +424,165 @@ class ConsumerTests: XCTestCase {
         XCTAssertEqual(meta.streamSequence, 2)
         XCTAssertEqual(meta.consumerSequence, 2)
         try await msg.ack()
+    }
+
+    func testFetchEmptyTerminatesWithoutHang() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        // A fetch on an empty consumer must terminate, not hang; race it against a
+        // wall-clock budget that returns -1 if the fetch hung.
+        let count = try await withThrowingTaskGroup(of: Int.self) { group -> Int in
+            group.addTask {
+                let batch = try await consumer.fetch(batch: 5, expires: 1)
+                var n = 0
+                for try await _ in batch { n += 1 }
+                return n
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 8 * 1_000_000_000)
+                return -1
+            }
+            let first = try await group.next()!
+            group.cancelAll()
+            return first
+        }
+        XCTAssertEqual(count, 0, "empty fetch should return 0 messages (-1 means it hung)")
+
+        // The consumer must still be usable after the empty fetch.
+        _ = try await ctx.publish("foo.A", message: "hi".data(using: .utf8)!).wait()
+        let batch = try await consumer.fetch(batch: 1, expires: 2)
+        var got = 0
+        for try await msg in batch {
+            try await msg.ack()
+            got += 1
+        }
+        XCTAssertEqual(got, 1)
+
+        try await client.close()
+    }
+
+    func testFetchCancellationTearsDownSubscription() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        let baseline = client.connectionHandler?.subscriptionCount ?? -1
+
+        // Empty consumer: the fetch blocks waiting for a message.
+        let task = Task {
+            let batch = try await consumer.fetch(batch: 1, expires: 30)
+            for try await _ in batch {}
+        }
+        // Let the fetch create its inbox subscription and start waiting, then cancel.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        task.cancel()
+        _ = try? await task.value
+
+        // Teardown runs asynchronously after cancellation; poll briefly for it.
+        var count = client.connectionHandler?.subscriptionCount ?? -1
+        for _ in 0..<20 where count != baseline {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            count = client.connectionHandler?.subscriptionCount ?? -1
+        }
+        XCTAssertEqual(count, baseline, "cancelled fetch leaked its inbox subscription")
+
+        try await client.close()
+    }
+
+    func testFetchEarlyBreakTearsDownSubscription() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        for i in 0..<5 {
+            _ = try await ctx.publish("foo.\(i)", message: "hi".data(using: .utf8)!).wait()
+        }
+
+        let baseline = client.connectionHandler?.subscriptionCount ?? -1
+
+        // Consume one message then break out early. The fetch's inbox subscription
+        // must still be torn down, not leaked.
+        let batch = try await consumer.fetch(batch: 5, expires: 30)
+        for try await msg in batch {
+            try await msg.ack()
+            break
+        }
+
+        var count = client.connectionHandler?.subscriptionCount ?? -1
+        for _ in 0..<20 where count != baseline {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            count = client.connectionHandler?.subscriptionCount ?? -1
+        }
+        XCTAssertEqual(count, baseline, "early-break fetch leaked its inbox subscription")
+
+        try await client.close()
+    }
+
+    func testFetchCompletionTearsDownSubscription() async throws {
+        let bundle = Bundle.module
+        natsServer.start(
+            cfg: bundle.url(forResource: "jetstream", withExtension: "conf")!.relativePath)
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+
+        let ctx = JetStreamContext(client: client)
+        let stream = try await ctx.createStream(
+            cfg: StreamConfig(name: "test", subjects: ["foo.*"]))
+        let consumer = try await stream.createConsumer(cfg: ConsumerConfig(name: "cons"))
+
+        for i in 0..<3 {
+            _ = try await ctx.publish("foo.\(i)", message: "hi".data(using: .utf8)!).wait()
+        }
+
+        let baseline = client.connectionHandler?.subscriptionCount ?? -1
+
+        // Consume the whole batch to completion.
+        let batch = try await consumer.fetch(batch: 3, expires: 5)
+        var got = 0
+        for try await msg in batch {
+            try await msg.ack()
+            got += 1
+        }
+        XCTAssertEqual(got, 3)
+
+        var count = client.connectionHandler?.subscriptionCount ?? -1
+        for _ in 0..<20 where count != baseline {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            count = client.connectionHandler?.subscriptionCount ?? -1
+        }
+        XCTAssertEqual(count, baseline, "completed fetch leaked its inbox subscription")
+
+        try await client.close()
     }
 }

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -432,6 +432,32 @@ class CoreNatsTests: XCTestCase {
         try await client.close()
     }
 
+    func testUnsubscribeAfterWithWaitingConsumer() async throws {
+        natsServer.start()
+        logger.logLevel = .critical
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+        try await client.connect()
+        let sub = try await client.subscribe(subject: "test")
+        try await sub.unsubscribe(after: 3)
+
+        // Publish one-by-one to a waiting consumer (the continuation path): auto-unsubscribe
+        // must trigger after exactly 3 delivered messages.
+        let consumed = Task { () -> Int in
+            var i = 0
+            for try await _ in sub {
+                i += 1
+            }
+            return i
+        }
+        for _ in 0..<5 {
+            try await client.publish("msg".data(using: .utf8)!, subject: "test")
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        let i = try await consumed.value
+        XCTAssertEqual(i, 3, "Expected exactly 3 delivered before auto-unsubscribe")
+        try await client.close()
+    }
+
     func testConnect() async throws {
         natsServer.start()
         logger.logLevel = .critical

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -58,7 +58,8 @@ class CoreNatsTests: XCTestCase {
         ("testReconnectOnClosedConnection", testReconnectOnClosedConnection),
         ("testSubscribeMissingPermissions", testSubscribeMissingPermissions),
         ("testSubscribePermissionsRevoked", testSubscribePermissionsRevoked),
-
+        ("testUnsubscribeAfterWithWaitingConsumer", testUnsubscribeAfterWithWaitingConsumer),
+        ("testQueueGroupSurvivesReconnect", testQueueGroupSurvivesReconnect),
     ]
     var natsServer = NatsServer()
 
@@ -528,6 +529,57 @@ class CoreNatsTests: XCTestCase {
 
         // Check if the total number of messages received matches the number sent
         XCTAssertEqual(20, messagesReceived, "Mismatch in the number of messages sent and received")
+        try await client.close()
+    }
+
+    func testQueueGroupSurvivesReconnect() async throws {
+        natsServer.start()
+        let port = natsServer.port!
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions()
+            .url(URL(string: natsServer.clientURL)!)
+            .reconnectWait(1)
+            .build()
+        try await client.connect()
+
+        // Two members of one queue group: N messages produce exactly N deliveries
+        // across both. A lost queue group (plain fan-out) would double the count, which
+        // `assertForOverFulfill` rejects.
+        let delivered = XCTestExpectation(description: "each message delivered once")
+        delivered.expectedFulfillmentCount = 10
+        delivered.assertForOverFulfill = true
+
+        let sub1 = try await client.subscribe(subject: "q.subject", queue: "workers")
+        let sub2 = try await client.subscribe(subject: "q.subject", queue: "workers")
+        _ = try await client.rtt()  // ensure both SUBs reached the server
+
+        let collector1 = Task {
+            for try await _ in sub1 { delivered.fulfill() }
+        }
+        let collector2 = Task {
+            for try await _ in sub2 { delivered.fulfill() }
+        }
+
+        let reconnected = XCTestExpectation(description: "client reconnected")
+        client.on(.connected) { _ in reconnected.fulfill() }
+        natsServer.stop()
+        sleep(1)
+        natsServer.start(port: port)
+        await fulfillment(of: [reconnected], timeout: 10.0)
+        _ = try await client.rtt()  // ensure both re-SUBs were flushed after reconnect
+
+        let payload = "x".data(using: .utf8)!
+        for _ in 0..<10 {
+            try await client.publish(payload, subject: "q.subject")
+        }
+        try await client.flush()
+
+        await fulfillment(of: [delivered], timeout: 10.0)
+        // Give any erroneous duplicate deliveries a window to over-fulfill and fail.
+        _ = try await client.rtt()
+        collector1.cancel()
+        collector2.cancel()
         try await client.close()
     }
 

--- a/Tests/NatsTests/Integration/SlowConsumerTests.swift
+++ b/Tests/NatsTests/Integration/SlowConsumerTests.swift
@@ -1,0 +1,113 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Logging
+import NatsServer
+import XCTest
+
+@testable import Nats
+
+class SlowConsumerTests: XCTestCase {
+
+    static var allTests = [
+        ("testSlowConsumerEventFiresOnOverflow", testSlowConsumerEventFiresOnOverflow),
+        ("testSlowConsumerReArmsAfterDrain", testSlowConsumerReArmsAfterDrain),
+    ]
+
+    var natsServer = NatsServer()
+
+    override func tearDown() {
+        super.tearDown()
+        natsServer.stop()
+    }
+
+    func testSlowConsumerEventFiresOnOverflow() async throws {
+        natsServer.start()
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+
+        let expectation = XCTestExpectation(description: "slow consumer event was not fired")
+        expectation.assertForOverFulfill = true  // exactly one event per overflow episode
+        client.on(.error) { event in
+            if case .error(let err) = event,
+                let subErr = err as? NatsError.SubscriptionError,
+                case .slowConsumer = subErr
+            {
+                expectation.fulfill()
+            }
+        }
+        try await client.connect()
+
+        // Capacity 2 and we never read from the subscription, so once more than two
+        // messages are delivered the buffer overflows and must fire a slow consumer
+        // event exactly once.
+        _ = try await client.subscribe(subject: "foo", capacity: 2)
+        _ = try await client.rtt()  // ensure the SUB reached the server before publishing
+
+        let payload = "x".data(using: .utf8)!
+        for _ in 0..<10 {
+            try await client.publish(payload, subject: "foo")
+        }
+        try await client.flush()
+
+        await fulfillment(of: [expectation], timeout: 5.0)
+        try await client.close()
+    }
+
+    func testSlowConsumerReArmsAfterDrain() async throws {
+        natsServer.start()
+        logger.logLevel = .critical
+
+        let client = NatsClientOptions().url(URL(string: natsServer.clientURL)!).build()
+
+        let episodes = XCTestExpectation(description: "two slow consumer episodes")
+        episodes.expectedFulfillmentCount = 2
+        episodes.assertForOverFulfill = true
+        client.on(.error) { event in
+            if case .error(let err) = event,
+                let subErr = err as? NatsError.SubscriptionError,
+                case .slowConsumer = subErr
+            {
+                episodes.fulfill()
+            }
+        }
+        try await client.connect()
+
+        let sub = try await client.subscribe(subject: "foo", capacity: 2)
+        _ = try await client.rtt()
+
+        let payload = "x".data(using: .utf8)!
+        // Episode 1: overflow the buffer.
+        for _ in 0..<6 {
+            try await client.publish(payload, subject: "foo")
+        }
+        try await client.flush()
+        _ = try await client.rtt()  // let the inbound messages be processed
+
+        // Drain below capacity/2 so the slow-consumer signal re-arms.
+        var iter = sub.makeAsyncIterator()
+        _ = try await iter.next()
+        _ = try await iter.next()
+
+        // Episode 2: overflow again -> a second event must fire.
+        for _ in 0..<6 {
+            try await client.publish(payload, subject: "foo")
+        }
+        try await client.flush()
+
+        await fulfillment(of: [episodes], timeout: 5.0)
+        try await client.close()
+    }
+}


### PR DESCRIPTION
Resolves #120.

Four independent reliability fixes for the JetStream pull consumer and reconnect handling, one per
commit. No new dependencies. Each commit builds standalone.

## 1. `fix(encode): replace try! with throws on CONNECT and JetStream encode paths`

**Problem.** Encoding the CONNECT line and the JetStream stream/consumer configs used `try!`, so a
payload that failed to encode crashed the process instead of surfacing an error.

**Fix.** `writeClientOp` and the stream/consumer create paths now `throw`; the encode error propagates.
Both continuation-resume sites in `BatchBuffer` resume with the error instead of swallowing it. The
`#if SWIFT_NATS_BATCH_BUFFER_DISABLED` branch — which referenced an undefined `data` symbol and could
not compile under that flag — is repaired to encode the message.

**Why.** `try!` is only correct on statically-known-good input; here the input is user data (CONNECT
JSON, configs). The remaining `try!` (constant regex/header literals, Example/Benchmark targets) are on
known-good inputs and are left alone.

## 2. `fix(jetstream): bound pull fetch and tear it down on every exit`

**Problem (three bugs).** The pull-`fetch` loop relied on the server's `expires`/408 to end a wait,
used `unsubscribe()` to interrupt a waiting read, and tore the inbox subscription down by hand inside a
custom `AsyncIteratorProtocol`. So: with no idle heartbeat a lost pull request / 408 on reconnect could
wedge the loop forever; interrupting the wait via `unsubscribe()` led to a second unsubscribe on the
resulting `nil` (throwing `subscriptionClosed` out of `next()`); and an early `break` out of
`for try await … in fetch(...)` never reached the manual teardown, leaking the inbox subscription.

**Fix.** `fetch` now returns a `FetchResult` backed by an `AsyncThrowingStream`:
- A producer task runs the wait + JetStream status handling and `yield`s messages. The wait is bounded
  by one overall client-side deadline (`expires` + 1s grace, anchored to `ProcessInfo.systemUptime` —
  monotonic, no `ContinuousClock`, so iOS 13 / Linux safe), armed once; with an idle heartbeat it also
  races a `2× heartbeat` watchdog per read. A fired timer ends the wait by **cancelling the read**,
  never by unsubscribing.
- Teardown happens in **one** place — the stream's `onTermination` — firing exactly once on every exit
  (batch complete, thrown `FetchError`, cancellation, early `break`). The subscription may already be
  gone (terminal status / reconnect / close), which `unsubscribe()` reports as
  `subscriptionClosed`/`connectionClosed`; those are expected and ignored there, any other error logged.
- If the pull-request publish fails before the `FetchResult` is constructed, the just-created inbox
  subscription is torn down before the original error is rethrown.

**Why.** This mirrors how the Go (`jetstream/pull.go`: `select` over msgs / errs /
`time.After(req.Expires + 1*time.Second)` + `defer sub.subscription.Unsubscribe()`) and Rust
(async-nats: a pull `Batch` holds an ephemeral `Subscriber` that unsubscribes on `Drop`) clients bound a
fetch and tear it down once on every exit. The message-vs-watchdog race is safe: a dropped message is
unacked and redelivered for a pull consumer.

**Tests.** `testFetchEmptyTerminatesWithoutHang` (an empty-consumer fetch terminates within a wall-clock
budget instead of hanging and leaves the consumer reusable); `testFetch{Cancellation,EarlyBreak,Completion}TearsDownSubscription`
(each exit path returns the internal `subscriptionCount` read seam to baseline).

## 3. `feat(subscription): slow-consumer event and message accounting`

**(a) Slow-consumer event.** On subscription buffer overflow, messages were dropped silently (an
existing `TODO(pp)`). They now raise `NatsEvent.error(.slowConsumer)` once per overflow episode: the
signal latches when the buffer saturates and re-arms once it drains below half capacity (hysteresis), so
a subscription that never fully drains still gets a fresh event on each distinct episode. It is surfaced
on the existing connection-level `NatsEvent.error` stream, which has no per-subscription field, so it
does not identify which subscription overflowed. Adds the additive case `SubscriptionError.slowConsumer`.

**(b) Deliver outside the subscriptions lock (required by (a)).** `receiveMessage` can now fire the
slow-consumer event into user handlers; firing it under the `subscriptions` lock would deadlock a handler
that calls `subscribe`/`unsubscribe`. Both `handleIncomingMessage` overloads now look the subscription up
under the lock and deliver outside it. Message order is preserved — inbound is serialized on the event loop.

**(c) Message accounting (`delivered` / `received`).**
- `delivered` was incremented before a message was in hand (at suspend/attempt), so a cancelled/empty
  wait counted toward `unsubscribe(after:)` and could auto-remove the subscription early. It now
  increments only on a message actually delivered to the consumer (`.success` after the await).
- A separate `received` counter is added (messages accepted into the subscription — buffered or handed
  to a waiting consumer; drops are not counted). Commit 4 needs it. Two counters are required because the
  client-side auto-remove must wait until the consumer has actually pulled N: `removeSub` → `complete()`
  sets `closed`, and `nextMessage` checks `closed` before draining the buffer, so counting auto-remove on
  receive would truncate buffered-but-unread messages. `delivered` (consumer-pulled, drain-safe) drives
  auto-remove; `received` (accepted off the wire) drives the reconnect re-arm in commit 4.

**Tests.** `testSlowConsumerEventFiresOnOverflow` / `testSlowConsumerReArmsAfterDrain` (fires once per
episode and re-arms after drain; they use a new **internal** `subscribe(subject:queue:capacity:)` seam so
the tests do not flood the default buffer — the public `subscribe` is unchanged);
`testUnsubscribeAfterWithWaitingConsumer` (a waiting consumer fed one message at a time auto-unsubscribes
after exactly N delivered).

## 4. `fix(reconnect): restore queue group and auto-unsubscribe on resubscribe`

**Problem (three bugs).** On reconnect each subscription is re-SUB'd. (1) The re-SUB passed `nil` for the
queue group, silently demoting a queue subscriber to plain fan-out. (2) A subscription with an
auto-unsubscribe limit (`unsubscribe(after:)`) lost it — the re-SUB'd sid counts from zero on the server,
so the server delivered without bound until the client-side cap tripped. (3) A failed re-SUB was
logged-and-continued, so on a dead channel it fired one error per remaining subscription and still
reported `.connected` with a partially-restored set.

**Fix.**
- The re-SUB restores the queue group.
- For an auto-unsubscribe limit, the reconnect re-sends `UNSUB` with the remaining count `max - received`
  so the server re-arms the limit. The remaining count uses `received` (accepted off the wire), not
  `delivered` (consumer-pulled), so messages still buffered at disconnect are not double-granted. A
  subscription that already received its whole limit (`received >= max`) is skipped rather than re-SUB'd
  uncapped; it drains locally. `received` is read once to avoid a TOCTOU underflow on the subtraction.
- Subscription restore is now part of the connect attempt: `restoreSubscriptions()` runs inside
  `connect()`, before the reconnect-attempt counter is cleared. So `.connected` fires only after a full
  connect + restore (the client never reports connected with a subset of subscriptions restored), a
  restore failure throws before the counter reset and therefore stays bounded by `maxReconnects` (it
  reaches `close()` on give-up instead of retrying forever), and the initial connect is a no-op because
  the subscription set is empty. A failed re-SUB fires a single error and the whole connect + restore is
  retried.

**Why.** The queue-group restore and the remaining-count re-arm match nats.go `resendSubscriptions` and
async-nats `handle_reconnect`. Running restore inside `connect()` makes the attempt-counter reset the
single commit point of a successful attempt, so "TCP up but restore failing" is treated as a failed
attempt by the existing bound without special-casing.

**Tests.** `testQueueGroupSurvivesReconnect` (two members of one queue group survive a forced reconnect;
an `assertForOverFulfill` guard fails if the queue group were lost — plain fan-out would double the
delivery count).

## Breaking public API changes

- `FetchResult`: the nested `public struct FetchResult.FetchIterator` is removed and
  `FetchResult.AsyncIterator` now resolves to `AsyncThrowingStream<JetStreamMessage, Error>.Iterator`;
  the type becomes `final` and `Sendable`. The idiomatic `for try await … in fetch(...)` usage is
  unaffected; only code that spelled the iterator type explicitly is. `final` is required for a clean
  `Sendable` (no `@unchecked`), and the `AsyncThrowingStream` rewrite leaves no zero-break alternative.
- `NatsError.SubscriptionError.slowConsumer` is additive; downstream exhaustive `switch`es over
  `SubscriptionError` without `@unknown default` will need updating.

## Behavioral notes (for the changelog)

- A pull `fetch` is now always bounded by a client-side deadline (`expires` + 1s grace) even when an idle
  heartbeat is configured — previously a fetch could outlive `expires` as long as heartbeats kept
  arriving. The server's `expires`/408 still ends it first in the normal case; the client deadline is a
  backstop.
- Subscription-restore failures on reconnect now surface as `NatsEvent.error` events; previously they
  were only logged.

## Verification

`swift build` and `xcodebuild -scheme Nats` on macOS and iOS, the full test suite, and
`swift-format lint --configuration .swift-format -r --strict Sources Tests` all pass.
