### PR TITLE
AuthToken as a closure

### DIFF
--- a/Sources/Nats/NatsClient/NatsClient.swift
+++ b/Sources/Nats/NatsClient/NatsClient.swift
@@ -33,7 +33,7 @@ public enum NatsState: Sendable {
 public struct Auth: Sendable {
     var user: String?
     var password: String?
-    var token: String?
+    var tokenProvider: (@Sendable () async throws -> String)?
     var credentialsPath: URL?
     var nkeyPath: URL?
     var nkey: String?
@@ -47,7 +47,10 @@ public struct Auth: Sendable {
         self.password = password
     }
     init(token: String) {
-        self.token = token
+        self.tokenProvider = { token }
+    }
+    init(tokenProvider: @escaping @Sendable () async throws -> String) {
+        self.tokenProvider = tokenProvider
     }
     static func fromCredentials(_ credentials: URL) -> Auth {
         var auth = Auth()

--- a/Sources/Nats/NatsClient/NatsClientOptions.swift
+++ b/Sources/Nats/NatsClient/NatsClientOptions.swift
@@ -99,7 +99,21 @@ public class NatsClientOptions {
         if self.auth == nil {
             self.auth = Auth(token: token)
         } else {
-            self.auth?.token = token
+            self.auth?.tokenProvider = { token }
+        }
+        return self
+    }
+
+    /// Token used for token auth to NATS server, resolved on every connect and
+    /// reconnect so that short-lived tokens can be refreshed without rebuilding
+    /// the client.
+    public func token(
+        _ provider: @escaping @Sendable () async throws -> String
+    ) -> NatsClientOptions {
+        if self.auth == nil {
+            self.auth = Auth(tokenProvider: provider)
+        } else {
+            self.auth?.tokenProvider = provider
         }
         return self
     }

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -530,11 +530,13 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
     }
 
     private func sendClientConnectInit() async throws {
+        let authToken = try await self.auth?.tokenProvider?()
+
         var initialConnect = ConnectInfo(
             verbose: false, pedantic: false, userJwt: nil, nkey: "", name: "", echo: true,
             lang: self.lang, version: self.version, natsProtocol: .dynamic, tlsRequired: false,
             user: self.auth?.user ?? "", pass: self.auth?.password ?? "",
-            authToken: self.auth?.token ?? "", headers: true, noResponders: true)
+            authToken: authToken ?? "", headers: true, noResponders: true)
 
         if self.auth?.nkey != nil && self.auth?.nkeyPath != nil {
             throw NatsError.ConnectError.invalidConfig("cannot use both nkey and nkeyPath")

--- a/Tests/NatsTests/Integration/ConnectionTests.swift
+++ b/Tests/NatsTests/Integration/ConnectionTests.swift
@@ -13,6 +13,7 @@
 
 import Logging
 import NIO
+import NIOConcurrencyHelpers
 import Nats
 import NatsServer
 import XCTest
@@ -37,6 +38,7 @@ class CoreNatsTests: XCTestCase {
         ("testReconnect", testReconnect),
         ("testUsernameAndPassword", testUsernameAndPassword),
         ("testTokenAuth", testTokenAuth),
+        ("testTokenProviderRefreshedOnReconnect", testTokenProviderRefreshedOnReconnect),
         ("testCredentialsAuth", testCredentialsAuth),
         ("testNkeyAuth", testNkeyAuth),
         ("testNkeyAuthFile", testNkeyAuthFile),
@@ -572,6 +574,48 @@ class CoreNatsTests: XCTestCase {
             XCTFail("Expected auth error; got: \(error)")
         }
         XCTFail("Expected error from connect")
+    }
+
+    func testTokenProviderRefreshedOnReconnect() async throws {
+        logger.logLevel = .critical
+        let bundle = Bundle.module
+        natsServer.start(cfg: bundle.url(forResource: "token", withExtension: "conf")!.relativePath)
+        let port = natsServer.port!
+
+        // The server accepts "s3cr3t" now and only "r0tat3d" after the restart below,
+        // so reconnecting can only succeed if the provider is consulted again.
+        let token = NIOLockedValueBox("s3cr3t")
+        let client = NatsClientOptions()
+            .url(URL(string: natsServer.clientURL)!)
+            .token { token.withLockedValue { $0 } }
+            .reconnectWait(1)
+            .build()
+
+        try await client.connect()
+        let sub = try await client.subscribe(subject: "foo")
+
+        let reconnected = XCTestExpectation(description: "client did not reconnect")
+        client.on(.connected) { _ in reconnected.fulfill() }
+
+        token.withLockedValue { $0 = "r0tat3d" }
+        natsServer.stop()
+        sleep(1)
+        natsServer.start(
+            port: port,
+            cfg: bundle.url(forResource: "token_rotated", withExtension: "conf")!.relativePath)
+        await fulfillment(of: [reconnected], timeout: 10.0)
+
+        let payload = "hello".data(using: .utf8)!
+        let received = XCTestExpectation(description: "subscription did not survive the reconnect")
+        let iter = sub.makeAsyncIterator()
+        Task {
+            if let message = try await iter.next() {
+                XCTAssertEqual(message.payload, payload)
+                received.fulfill()
+            }
+        }
+        try await client.publish(payload, subject: "foo")
+        await fulfillment(of: [received], timeout: 5.0)
     }
 
     func testCredentialsAuth() async throws {

--- a/Tests/NatsTests/Integration/Resources/token_rotated.conf
+++ b/Tests/NatsTests/Integration/Resources/token_rotated.conf
@@ -1,0 +1,3 @@
+authorization {
+  token: r0tat3d
+}


### PR DESCRIPTION
The token was captured when the client was built and reused verbatim for the lifetime of the client, so a token that expired while connected made every subsequent reconnect fail with an authorization violation. The only workaround was to rebuild the client and re-create its subscriptions.

**Proposal:**  
Add a `token(_:)` overload taking a closure, mirroring the string-or-function token accepted by nats.js, without impacting the existing clients that don't need dynamic tokens.

### Usage

```swift
// unchanged
let client = NatsClientOptions()
    .url(url)
    .token("s3cr3t")
    .build()

// new: resolved on every connect and reconnect
let client = NatsClientOptions()
    .url(url)
    .token { try await refreshToken() }
    .build()

A synchronous closure converts implicitly (.token { keychain.currentToken }).
If the provider throws, that connect attempt fails and the client keeps
reconnecting per reconnectWait / maxReconnects.
```