### PR TITLE
Fix Linux build failures (CryptoKit, FoundationNetworking, Combine)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     branches: [ main, release/* ]
 
 jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: swift:6.2-noble
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v4
+    - name: Install system dependencies
+      run: |
+        apt-get update
+        apt-get install -y libsodium-dev curl
+    - name: Install nats-server
+      run: curl --fail https://binaries.nats.dev/nats-io/nats-server/v2@latest | PREFIX='/usr/local/bin' sh
+    - name: Build
+      run: swift build
+    - name: Test
+      run: swift test
   macos:
     runs-on: macos-15
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,8 @@ fastlane/screenshots
 fastlane/test_output
 /.swiftpm
 .DS_Store
+
+# NatsServer test helper writes JetStream storage under a literal "file:/..."
+# path instead of stripping the URL scheme - not a real directory to track.
+/file:
 .vscode

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(url: "https://github.com/nats-io/nkeys.swift.git", from: "0.1.2"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/Jarema/swift-nuid.git", from: "0.2.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
     ],
     targets: [
         .target(
@@ -38,6 +39,7 @@ let package = Package(
             dependencies: [
                 "Nats",
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Crypto", package: "swift-crypto"),
             ]),
         .target(
             name: "NatsServer",

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.68.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.2"),
         .package(url: "https://github.com/nats-io/nkeys.swift.git", from: "0.1.2"),
+        // Pinned below nkeys.swift's newer swift-sodium releases: 0.10.0+ use libsodium's
+        // AEGIS/KEM APIs, which aren't available on Ubuntu (libsodium-dev is stuck at 1.0.18).
+        .package(url: "https://github.com/jedisct1/swift-sodium.git", exact: "0.9.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/Jarema/swift-nuid.git", from: "0.2.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/nats-io/nkeys.swift.git", from: "0.1.2"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/Jarema/swift-nuid.git", from: "0.2.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
     ],
     targets: [
         .target(

--- a/Sources/JetStream/Consumer.swift
+++ b/Sources/JetStream/Consumer.swift
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import CryptoKit
+import Crypto
 import Foundation
 import Nuid
 

--- a/Sources/JetStream/JetStreamContext.swift
+++ b/Sources/JetStream/JetStreamContext.swift
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Combine
 import Foundation
 import Nats
 import Nuid

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -14,6 +14,9 @@
 import Atomics
 import Dispatch
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 import NIO
 import NIOConcurrencyHelpers
 import NIOFoundationCompat

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -14,9 +14,6 @@
 import Atomics
 import Dispatch
 import Foundation
-#if canImport(FoundationNetworking)
-    import FoundationNetworking
-#endif
 import NIO
 import NIOConcurrencyHelpers
 import NIOFoundationCompat
@@ -543,7 +540,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
             throw NatsError.ConnectError.invalidConfig("cannot use both nkey and nkeyPath")
         }
         if let auth = self.auth, let credentialsPath = auth.credentialsPath {
-            let credentials = try await URLSession.shared.data(from: credentialsPath).0
+            let credentials = try Data(contentsOf: credentialsPath)
             guard let jwt = JwtUtils.parseDecoratedJWT(contents: credentials) else {
                 throw NatsError.ConnectError.invalidConfig(
                     "failed to extract JWT from credentials file")
@@ -563,7 +560,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
             initialConnect.userJwt = String(data: jwt, encoding: .utf8)!
         }
         if let nkey = self.auth?.nkeyPath {
-            let nkeyData = try await URLSession.shared.data(from: nkey).0
+            let nkeyData = try Data(contentsOf: nkey)
 
             guard let nkeyContent = String(data: nkeyData, encoding: .utf8) else {
                 throw NatsError.ConnectError.invalidConfig("failed to read NKEY file")

--- a/Tests/NatsTests/Unit/JwtTests.swift
+++ b/Tests/NatsTests/Unit/JwtTests.swift
@@ -27,7 +27,7 @@ class JwtTests: XCTestCase {
         let currentFile = URL(fileURLWithPath: #file)
         let testDir = currentFile.deletingLastPathComponent().deletingLastPathComponent()
         let resourceURL = testDir.appendingPathComponent("Integration/Resources/TestUser.creds")
-        let credsData = try await URLSession.shared.data(from: resourceURL).0
+        let credsData = try Data(contentsOf: resourceURL)
 
         let nkey = String(data: JwtUtils.parseDecoratedNKey(contents: credsData)!, encoding: .utf8)
         let expectedNkey = "SUACH75SWCM5D2JMJM6EKLR2WDARVGZT4QC6LX3AGHSWOMVAKERABBBRWM"


### PR DESCRIPTION
Resolves #125

The package currently fails to build on Linux. Three unrelated APIs that only exist on Apple platforms are used unconditionally:

- `Consumer.swift` imports `CryptoKit` for `SHA256.hash(data:)`. Not available on Linux at all.
- `NatsConnection.swift` uses `URLSession.shared` (for reading credentials/nkey files) without importing `FoundationNetworking`, which is where `URLSession` lives on swift-corelibs-foundation.
- Even after fixing the import, `URLSession` on Linux doesn't support `file://` URLs (only http/https), so credentials/nkey loading would still break there. These are local file reads to begin with, so I switched them to `Data(contentsOf:)`.
- `JetStreamContext.swift` had an unused `import Combine`, which has no Linux implementation.

Changes:

- Replace `CryptoKit` with `swift-crypto`'s `Crypto` module for the one `SHA256.hash(data:)` call. Behavior is identical on Apple platforms (it re-exports CryptoKit there) and gives a real implementation on Linux. Added as a new dependency, ranged `"3.0.0"..<"5.0.0"` since the API used is stable across both major versions and this keeps room for consumers pinned to either.
- Pin `swift-sodium` to `0.9.1` explicitly. `nkeys.swift` depends on it without an upper bound, and 0.10.0+ requires libsodium AEGIS/KEM APIs that aren't in Ubuntu's `libsodium-dev` (still 1.0.18). Without pinning, a fresh `swift build` on a stock Ubuntu box fails to resolve.
- Read credentials/nkey files with `Data(contentsOf:)` instead of `URLSession`, drop the now-unneeded `FoundationNetworking` import.
- Remove the unused `Combine` import.
- Add a Linux job to CI (`swift:6.2-noble` container) so this doesn't regress silently.

Verified `swift build` and `swift test` pass on both macOS and Linux (podman, `swift:6.2-noble`).