### PR TITLE
Fail outstanding RTT promises instead of leaking them

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,64 @@
+# Local patches
+
+This fork carries patches that are not (yet) upstream. Everything else is a verbatim copy of
+[`nats-io/nats.swift`](https://github.com/nats-io/nats.swift).
+
+Branch `traderverse/rtt-promise-leak` is based on upstream `a9031f129810c5855d5f85771f9523d9b7d707d4`
+(`main`, 9 Apr 2026) — the revision `traderverse-ios-v3` was already pinned to, so the patch is
+the only thing that changed for that app.
+
+## 1. RTT promises are never left unfulfilled
+
+**Files:** `Sources/Nats/RttCommand.swift`, `Sources/Nats/ConcurrentQueue.swift`,
+`Sources/Nats/NatsConnection.swift`
+**Test:** `Tests/NatsTests/Unit/RttCommandTests.swift`
+
+`ConnectionHandler.sendPing()` enqueues an `RttCommand` holding an
+`EventLoopPromise<TimeInterval>`, and that promise is only ever completed in the `.pong`
+branch of the message loop. Nothing drained `pingQueue` on `channelInactive`,
+`handleDisconnect()`, `disconnect()`, `suspend()` or `close()`, so a connection that dies with
+pings in flight — a stale connection, a backgrounded phone, a NAT rebind — abandoned up to
+three promises. They stayed alive with the `ConnectionHandler`, and whatever eventually
+released the `NatsClient` deallocated them unfulfilled. SwiftNIO traps on exactly that in
+`EventLoopFuture.deinit`:
+
+```
+Nats/RttCommand.swift:22: Fatal error: leaking promise created at (file: "Nats/RttCommand.swift", line: 22)
+```
+
+The check is inside NIO's `debugOnly`, so it crashes every debug build of the host
+application and leaks silently in release.
+
+The patch:
+
+- `RttCommand.fail(_:)` plus a `deinit` that completes the promise with
+  `NatsError.ClientError.connectionClosed`. This is the backstop that makes the trap
+  unreachable no matter which path drops a command. Completing an already-completed promise
+  is a no-op in NIO (`EventLoopFuture._setValue` returns early once `_value != nil`), so a
+  command that was answered keeps its measured round trip time.
+- `ConcurrentQueue.drain()` — takes every element under one lock.
+- `ConnectionHandler.failOutstandingPings(_:)`, called from `channelInactive`,
+  `handleDisconnect()`, `disconnect()`, `close()` and `suspend()`, so a pending
+  `getRoundTripTime()` throws promptly instead of hanging until the client is released.
+
+## 2. `outstandingPings` can no longer stick above its threshold
+
+**File:** `Sources/Nats/NatsConnection.swift` (folded into `failOutstandingPings(_:)` above)
+
+`outstandingPings` was only reset by an incoming `PONG`, but `sendPing()` returns early via
+`handleDisconnect()` once the counter exceeds 2 — *without* writing the `PING` that could earn
+that `PONG`. A connection that missed three pings therefore stayed stuck above the threshold
+for the rest of the client's life and force-disconnected on every subsequent ping tick, even
+after reconnecting cleanly. `failOutstandingPings(_:)` resets the counter alongside the drain.
+
+## Rebasing onto a newer upstream
+
+```bash
+git remote add upstream https://github.com/nats-io/nats.swift
+git fetch upstream
+git rebase <upstream-sha> traderverse/rtt-promise-leak
+swift test --filter RttCommandTests
+```
+
+Then repoint `traderverse-ios-v3.xcodeproj`'s package reference at the new revision — it pins
+by SHA, deliberately, so a rebase here cannot reach the app without someone deciding it should.

--- a/Sources/Nats/ConcurrentQueue.swift
+++ b/Sources/Nats/ConcurrentQueue.swift
@@ -28,4 +28,16 @@ internal final class ConcurrentQueue<T: Sendable>: Sendable {
             return array.removeFirst()
         }
     }
+
+    /// Take every element and leave the queue empty.
+    ///
+    /// One locked pass rather than a `while let _ = dequeue()` loop, so a concurrent
+    /// `enqueue` cannot slip an element in between two dequeues and be dropped by a caller
+    /// that believes it has drained everything.
+    func drain() -> [T] {
+        elements.withLockedValue { array in
+            defer { array.removeAll() }
+            return array
+        }
+    }
 }

--- a/Sources/Nats/NatsConnection.swift
+++ b/Sources/Nats/NatsConnection.swift
@@ -777,6 +777,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
         guard let eventLoop = self.channel?.eventLoop else {
             self.state.withLockedValue { $0 = .closed }
             self.pingTask?.cancel()
+            self.failOutstandingPings(NatsError.ClientError.connectionClosed)
             self.fire(.closed)
             return
         }
@@ -785,6 +786,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
         eventLoop.execute {
             self.state.withLockedValue { $0 = .closed }
             self.pingTask?.cancel()
+            self.failOutstandingPings(NatsError.ClientError.connectionClosed)
             self.channel?.close(mode: .all, promise: promise)
         }
 
@@ -800,6 +802,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
 
     private func disconnect() async throws {
         self.pingTask?.cancel()
+        self.failOutstandingPings(NatsError.ClientError.connectionClosed)
         try await self.channel?.close().get()
     }
 
@@ -811,6 +814,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
         guard let eventLoop = self.channel?.eventLoop else {
             // Set state to suspended even if channel is nil
             self.state.withLockedValue { $0 = .suspended }
+            self.failOutstandingPings(NatsError.ClientError.connectionClosed)
             return
         }
         let promise = eventLoop.makePromise(of: Void.self)
@@ -821,6 +825,8 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
                 currentState = .suspended
                 return wasConnected
             }
+
+            self.failOutstandingPings(NatsError.ClientError.connectionClosed)
 
             if shouldClose {
                 self.pingTask?.cancel()
@@ -851,6 +857,25 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
     func reconnect() async throws {
         try await suspend()
         try await resume()
+    }
+
+    /// Complete every queued RTT command, for a connection that is not going to answer.
+    ///
+    /// A command is enqueued per outgoing `PING` and only completed by the matching `PONG`,
+    /// so a connection that dies with pings in flight leaves promises unfulfilled. NIO traps
+    /// on an unfulfilled promise in `EventLoopFuture.deinit` (`debugOnly`), which crashes
+    /// debug builds of the host application the moment the client is released.
+    ///
+    /// Resetting `outstandingPings` is part of the same fix rather than a separate one: the
+    /// counter is otherwise only cleared by an incoming `PONG`, and `sendPing` returns early
+    /// once it exceeds 2 — *without* writing the `PING` that could earn that `PONG`. A
+    /// connection that misses three pings therefore stays stuck above the threshold and
+    /// force-disconnects on every subsequent ping tick, even after it reconnects cleanly.
+    internal func failOutstandingPings(_ error: Error) {
+        for rttCommand in pingQueue.drain() {
+            rttCommand.fail(error)
+        }
+        outstandingPings.store(0, ordering: AtomicStoreOrdering.relaxed)
     }
 
     internal func sendPing(_ rttCommand: RttCommand? = nil) async {
@@ -913,6 +938,8 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
             continuation.resume(throwing: errorToUse)
         }
 
+        failOutstandingPings(errorToUse)
+
         let shouldHandleDisconnect = state.withLockedValue { $0 == .connected }
         if shouldHandleDisconnect {
             handleDisconnect()
@@ -938,6 +965,7 @@ final class ConnectionHandler: ChannelInboundHandler, Sendable {
 
     func handleDisconnect() {
         state.withLockedValue { $0 = .disconnected }
+        failOutstandingPings(NatsError.ClientError.connectionClosed)
         if let channel = self.channel {
             let promise = channel.eventLoop.makePromise(of: Void.self)
             Task {

--- a/Sources/Nats/RttCommand.swift
+++ b/Sources/Nats/RttCommand.swift
@@ -33,6 +33,30 @@ internal final class RttCommand: Sendable {
         promise?.succeed(rtt)
     }
 
+    /// Complete the promise for a PONG that is never going to arrive.
+    ///
+    /// Anything holding queued commands must call this before dropping them — see
+    /// `ConnectionHandler.failOutstandingPings(_:)`.
+    func fail(_ error: Error) {
+        promise?.fail(error)
+    }
+
+    deinit {
+        // A command is enqueued on `PING` and only completed when the matching `PONG` comes
+        // back. A connection that goes stale — a dead socket, a backgrounded phone — never
+        // sends that `PONG`, so the command is dropped along with the connection handler
+        // while its promise is still unfulfilled. NIO traps on exactly that in
+        // `EventLoopFuture.deinit`: `fatalError("leaking promise created at …")`, which is
+        // `debugOnly`, so it takes down every debug build of the host application and leaks
+        // silently in release.
+        //
+        // Completing here is safe on both counts:
+        // - Completing an already-completed promise is a no-op — `EventLoopFuture._setValue`
+        //   returns early once `_value != nil`.
+        // - `fail` is callable from any thread; it hops to the event loop when needed.
+        promise?.fail(NatsError.ClientError.connectionClosed)
+    }
+
     func getRoundTripTime() async throws -> TimeInterval {
         try await promise?.futureResult.get() ?? 0
     }

--- a/Tests/NatsTests/Unit/RttCommandTests.swift
+++ b/Tests/NatsTests/Unit/RttCommandTests.swift
@@ -1,0 +1,90 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import NIOCore
+import NIOEmbedded
+import XCTest
+
+@testable import Nats
+
+/// An RTT command is enqueued per outgoing `PING` and completed by the matching `PONG`.
+/// A connection that dies with pings in flight never sends that `PONG`, so these tests pin
+/// down what happens to the promise when the command is dropped instead of completed.
+class RttCommandTests: XCTestCase {
+
+    static var allTests = [
+        ("testDroppedCommandFailsItsPromise", testDroppedCommandFailsItsPromise),
+        ("testCompletedCommandKeepsItsValue", testCompletedCommandKeepsItsValue),
+        ("testDrainEmptiesTheQueue", testDrainEmptiesTheQueue),
+    ]
+
+    /// Without this, the promise deinits unfulfilled, which is what NIO traps on in
+    /// `EventLoopFuture.deinit`: `fatalError("leaking promise created at …")`, taking down
+    /// every debug build of the host application. The trap itself needs a real event loop —
+    /// `EmbeddedEventLoop` does not track promise creation — so here the same regression
+    /// shows up as a plain failure instead.
+    func testDroppedCommandFailsItsPromise() throws {
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+
+        var command: RttCommand? = RttCommand.makeFrom(channel: channel)
+        let future = command!.promise!.futureResult
+
+        var result: Result<TimeInterval, Error>?
+        future.whenComplete { result = $0 }
+
+        XCTAssertNil(result, "the promise must not complete while the command is alive")
+        command = nil
+
+        switch result {
+        case .failure(let error):
+            // `ClientError` is not `Equatable`, so match the case rather than the value.
+            guard let clientError = error as? NatsError.ClientError,
+                case .connectionClosed = clientError
+            else {
+                XCTFail("dropped command failed with an unexpected error: \(error)")
+                return
+            }
+        case .success(let rtt):
+            XCTFail("dropped command reported a round trip time of \(rtt)")
+        case nil:
+            XCTFail("dropped command left its promise unfulfilled")
+        }
+    }
+
+    /// The failure above is a backstop, not an override: a command that was answered keeps
+    /// the round trip time it measured.
+    func testCompletedCommandKeepsItsValue() throws {
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+
+        var command: RttCommand? = RttCommand.makeFrom(channel: channel)
+        let future = command!.promise!.futureResult
+
+        command!.setRoundTripTime()
+        command = nil
+
+        XCTAssertGreaterThanOrEqual(try future.wait(), 0)
+    }
+
+    func testDrainEmptiesTheQueue() {
+        let queue = ConcurrentQueue<Int>()
+        queue.enqueue(1)
+        queue.enqueue(2)
+        queue.enqueue(3)
+
+        XCTAssertEqual(queue.drain(), [1, 2, 3])
+        XCTAssertNil(queue.dequeue())
+        XCTAssertEqual(queue.drain(), [])
+    }
+}


### PR DESCRIPTION
An `RttCommand` is enqueued per outgoing PING and only completed when the matching PONG arrives. Nothing drained `pingQueue` on `channelInactive`, `handleDisconnect()`, `disconnect()`, `suspend()` or `close()`, so a connection that dies with pings in flight abandons up to three `EventLoopPromise`s. They outlive the channel along with the `ConnectionHandler`, and whatever finally releases the `NatsClient` deallocates them unfulfilled — which SwiftNIO traps on in `EventLoopFuture.deinit`:

    Nats/RttCommand.swift:22: Fatal error: leaking promise created at
    (file: "Nats/RttCommand.swift", line: 22)

The check sits inside NIO's `debugOnly`, so it takes down every debug build of the host application and leaks silently in release. An iOS app backgrounded long enough for its socket to go stale hits it on the next client rebuild.

Add `RttCommand.deinit` completing the promise with `connectionClosed` as the backstop, `ConcurrentQueue.drain()`, and `failOutstandingPings(_:)` on the handler so queued commands are failed promptly on every teardown path rather than at deallocation.

`failOutstandingPings(_:)` also resets `outstandingPings`, which was previously cleared only by an incoming PONG. Once it exceeded 2, `sendPing()` returned early via `handleDisconnect()` without writing the PING that could earn that PONG, so the counter stayed stuck and the connection force-disconnected on every ping tick for the rest of the client's life — including after a clean reconnect.